### PR TITLE
Add Vue login and home pages

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,20 @@
+# Vue Giriş Uygulaması
+
+Bu proje, Vue 3 ve Vue Router kullanarak oluşturulmuş basit bir giriş-akış şablonu sunar.
+
+## Özellikler
+
+- Kullanıcı adı ve şifre doğrulaması (örnek kimlik bilgileri: `admin` / `123456`)
+- Doğru girişte "Ana Sayfa" ekranına yönlendirme
+- Router seviyesinde korunan sayfa ve yönlendirme
+- Gelişmiş görsel tasarıma sahip modern login formu
+
+## Komutlar
+
+> Not: Paketleri yüklemek için internete erişim gereklidir.
+
+```bash
+npm install
+npm run dev
+npm run build
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Giriş Paneli</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "vue": "^3.4.21",
+    "vue-router": "^4.3.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.4",
+    "@vue/test-utils": "^2.4.5",
+    "jsdom": "^24.0.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.3",
+    "vitest": "^1.3.1",
+    "vue-tsc": "^2.0.6",
+    "@testing-library/jest-dom": "^6.4.2"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="app-shell">
+    <AppHeader />
+    <main class="app-content">
+      <RouterView />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { RouterView } from 'vue-router';
+import AppHeader from '@/components/AppHeader.vue';
+</script>
+
+<style scoped>
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #f1f5f9 0%, #ffffff 100%);
+}
+
+.app-content {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
+</style>

--- a/frontend/src/assets/base.css
+++ b/frontend/src/assets/base.css
@@ -1,0 +1,34 @@
+:root {
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f1f5f9;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.45);
+  outline-offset: 2px;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+button {
+  font: inherit;
+}

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,0 +1,11 @@
+@import './base.css';
+
+body {
+  background: radial-gradient(circle at 10% 20%, rgba(37, 99, 235, 0.18), transparent 35%),
+    radial-gradient(circle at 90% 10%, rgba(59, 130, 246, 0.15), transparent 45%),
+    #f8fafc;
+}
+
+#app {
+  min-height: 100vh;
+}

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -1,0 +1,90 @@
+<template>
+  <header class="app-header">
+    <div class="branding">
+      <span class="logo" aria-hidden="true">🔐</span>
+      <span class="title">Giriş Paneli</span>
+    </div>
+    <nav class="navigation">
+      <RouterLink v-if="isAuthenticated" to="/ana-sayfa">Ana Sayfa</RouterLink>
+      <button v-if="isAuthenticated" type="button" class="logout" @click="handleLogout">
+        Çıkış Yap
+      </button>
+    </nav>
+  </header>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { RouterLink, useRouter } from 'vue-router';
+import { useAuth } from '@/composables/useAuth';
+
+const router = useRouter();
+const auth = useAuth();
+const isAuthenticated = computed(() => auth.state.isAuthenticated);
+
+const handleLogout = () => {
+  auth.logout();
+  router.push({ name: 'login' });
+};
+</script>
+
+<style scoped>
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 2rem;
+  background-color: #0f172a;
+  color: #f8fafc;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.2);
+}
+
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.logo {
+  font-size: 1.75rem;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.navigation {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.navigation a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.navigation a:hover {
+  opacity: 0.75;
+}
+
+.logout {
+  background: transparent;
+  border: 1px solid rgba(248, 250, 252, 0.6);
+  border-radius: 9999px;
+  padding: 0.4rem 1rem;
+  color: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.logout:hover {
+  background: #f8fafc;
+  color: #0f172a;
+}
+</style>

--- a/frontend/src/composables/useAuth.ts
+++ b/frontend/src/composables/useAuth.ts
@@ -1,0 +1,50 @@
+import { reactive, toRefs } from 'vue';
+
+interface Credentials {
+  username: string;
+  password: string;
+}
+
+const VALID_CREDENTIALS: Credentials = {
+  username: 'admin',
+  password: '123456'
+};
+
+const state = reactive({
+  isAuthenticated: false,
+  lastError: ''
+});
+
+export const useAuth = () => {
+  const login = (credentials: Credentials) => {
+    if (
+      credentials.username === VALID_CREDENTIALS.username &&
+      credentials.password === VALID_CREDENTIALS.password
+    ) {
+      state.isAuthenticated = true;
+      state.lastError = '';
+      return true;
+    }
+
+    state.isAuthenticated = false;
+    state.lastError = 'Kullanıcı adı veya şifre hatalı.';
+    return false;
+  };
+
+  const logout = () => {
+    state.isAuthenticated = false;
+    state.lastError = '';
+  };
+
+  const resetError = () => {
+    state.lastError = '';
+  };
+
+  return {
+    ...toRefs(state),
+    state,
+    login,
+    logout,
+    resetError
+  };
+};

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,9 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import router from './router';
+import './assets/main.css';
+
+const app = createApp(App);
+
+app.use(router);
+app.mount('#app');

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,0 +1,34 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import LoginView from '@/views/LoginView.vue';
+import HomeView from '@/views/HomeView.vue';
+import { authGuard } from '@/router/middleware';
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/',
+      redirect: { name: 'login' }
+    },
+    {
+      path: '/giris',
+      name: 'login',
+      component: LoginView,
+      meta: { layout: 'auth' }
+    },
+    {
+      path: '/ana-sayfa',
+      name: 'home',
+      component: HomeView,
+      meta: { requiresAuth: true }
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      redirect: { name: 'login' }
+    }
+  ]
+});
+
+router.beforeEach(authGuard);
+
+export default router;

--- a/frontend/src/router/middleware.ts
+++ b/frontend/src/router/middleware.ts
@@ -1,0 +1,22 @@
+import type { NavigationGuardNext, RouteLocationNormalized } from 'vue-router';
+import { useAuth } from '@/composables/useAuth';
+
+export const authGuard = (
+  to: RouteLocationNormalized,
+  _from: RouteLocationNormalized,
+  next: NavigationGuardNext
+) => {
+  const auth = useAuth();
+
+  if (to.meta.requiresAuth && !auth.state.isAuthenticated) {
+    next({ name: 'login', query: { redirect: to.fullPath } });
+    return;
+  }
+
+  if (to.name === 'login' && auth.state.isAuthenticated) {
+    next({ name: 'home' });
+    return;
+  }
+
+  next();
+};

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,0 +1,59 @@
+<template>
+  <section class="home-wrapper" aria-labelledby="home-title">
+    <header>
+      <h1 id="home-title">Ana Sayfa</h1>
+      <p class="home-subtitle">
+        Hoş geldiniz! Bu alan ileride oluşturacağımız diğer modüller için başlangıç noktasıdır.
+      </p>
+    </header>
+
+    <article class="home-card">
+      <h2>Sonraki Adımlar</h2>
+      <ul>
+        <li>Yeni sayfalar ekleyip router üzerinden bağlantı kurabilirsiniz.</li>
+        <li>Gerçek bir API ile kimlik doğrulaması entegre edebilirsiniz.</li>
+        <li>Dashboard, raporlar veya ayarlar gibi alt sayfalar oluşturabilirsiniz.</li>
+      </ul>
+    </article>
+  </section>
+</template>
+
+<style scoped>
+.home-wrapper {
+  width: min(720px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+  color: #0f172a;
+}
+
+header h1 {
+  font-size: 2.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.home-subtitle {
+  color: #475569;
+  font-size: 1.05rem;
+}
+
+.home-card {
+  padding: 2rem;
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.home-card h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.home-card ul {
+  display: grid;
+  gap: 0.75rem;
+  list-style: disc inside;
+  color: #1e293b;
+}
+</style>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,0 +1,182 @@
+<template>
+  <section class="login-wrapper" aria-labelledby="login-title">
+    <h1 id="login-title">Hesabınıza giriş yapın</h1>
+    <p class="login-subtitle">
+      Ana sayfaya ulaşmak için kullanıcı adı ve şifrenizi girin.
+      <span class="hint">(admin / 123456)</span>
+    </p>
+
+    <form class="login-form" @submit.prevent="handleSubmit" novalidate>
+      <label class="form-field">
+        <span>Kullanıcı Adı</span>
+        <input
+          v-model.trim="form.username"
+          type="text"
+          name="username"
+          autocomplete="username"
+          required
+          placeholder="örn. admin"
+        />
+      </label>
+
+      <label class="form-field">
+        <span>Şifre</span>
+        <input
+          v-model="form.password"
+          type="password"
+          name="password"
+          autocomplete="current-password"
+          required
+          placeholder="örn. 123456"
+        />
+      </label>
+
+      <p v-if="error" class="form-error" role="alert">
+        {{ error }}
+      </p>
+
+      <button type="submit" class="submit-button" :disabled="isSubmitting">
+        <span v-if="!isSubmitting">Giriş Yap</span>
+        <span v-else>Kontrol ediliyor...</span>
+      </button>
+    </form>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useAuth } from '@/composables/useAuth';
+
+const router = useRouter();
+const route = useRoute();
+const auth = useAuth();
+const form = reactive({
+  username: '',
+  password: ''
+});
+
+const error = ref('');
+const isSubmitting = ref(false);
+
+watch(
+  () => [form.username, form.password],
+  () => {
+    if (error.value) {
+      error.value = '';
+      auth.resetError();
+    }
+  }
+);
+
+const handleSubmit = () => {
+  if (isSubmitting.value) return;
+
+  isSubmitting.value = true;
+  error.value = '';
+
+  const success = auth.login({
+    username: form.username,
+    password: form.password
+  });
+
+  if (success) {
+    const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : undefined;
+    router.push(redirect ?? { name: 'home' });
+  } else {
+    error.value = auth.state.lastError;
+  }
+
+  isSubmitting.value = false;
+};
+</script>
+
+<style scoped>
+.login-wrapper {
+  width: min(420px, 100%);
+  padding: 2.5rem 2rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(6px);
+  text-align: center;
+}
+
+.login-wrapper h1 {
+  font-size: 1.75rem;
+  margin-bottom: 0.75rem;
+  color: #0f172a;
+}
+
+.login-subtitle {
+  margin-bottom: 2rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.hint {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #2563eb;
+}
+
+.login-form {
+  display: grid;
+  gap: 1.5rem;
+  text-align: left;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: #0f172a;
+}
+
+.form-field input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  background-color: #f8fafc;
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.form-error {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.1);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+}
+
+.submit-button {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 9999px;
+  border: none;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #f8fafc;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submit-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.submit-button:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(37, 99, 235, 0.25);
+}
+</style>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  }
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: fileURLToPath(new URL('./vitest.setup.ts', import.meta.url))
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  }
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,4 @@
+import { expect } from 'vitest';
+import matchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(matchers);


### PR DESCRIPTION
## Summary
- scaffold a Vue 3 + Vite frontend project structure for future expansion
- implement a reusable authentication composable, router guard, and navigation header
- add styled login and home views that redirect authenticated users appropriately

## Testing
- npm install *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68f0d624151c832b8c9cbeba63fb8078