### PR TITLE
Fix frontend container port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,5 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "5001:5001"
+      - "5001:80"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- map the frontend container's exposed nginx port 80 to host port 5001 so the site is reachable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0dab4ec50832b8bae7cb75dc1202c