### PR TITLE
Add authenticated dashboard layout with module placeholders

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,30 +1,17 @@
 <template>
   <div class="app-shell">
-    <AppHeader />
-    <main class="app-content">
-      <RouterView />
-    </main>
+    <RouterView />
   </div>
 </template>
 
 <script setup lang="ts">
 import { RouterView } from 'vue-router';
-import AppHeader from '@/components/AppHeader.vue';
 </script>
 
 <style scoped>
 .app-shell {
   min-height: 100vh;
   display: flex;
-  flex-direction: column;
-  background: linear-gradient(180deg, #f1f5f9 0%, #ffffff 100%);
-}
-
-.app-content {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem 1rem 3rem;
+  background: linear-gradient(180deg, rgba(241, 245, 249, 0.9) 0%, #ffffff 65%);
 }
 </style>

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -1,26 +1,34 @@
 <template>
   <header class="app-header">
-    <div class="branding">
-      <span class="logo" aria-hidden="true">🔐</span>
-      <span class="title">Giriş Paneli</span>
+    <div class="header-titles">
+      <span class="eyebrow">Envanter Kontrol</span>
+      <h1>{{ pageTitle }}</h1>
     </div>
-    <nav class="navigation">
-      <RouterLink v-if="isAuthenticated" to="/ana-sayfa">Ana Sayfa</RouterLink>
-      <button v-if="isAuthenticated" type="button" class="logout" @click="handleLogout">
+    <div class="header-actions">
+      <span class="user-chip" aria-label="Aktif kullanıcı">
+        <span class="avatar" aria-hidden="true">A</span>
+        <span class="username">admin</span>
+      </span>
+      <button type="button" class="logout" @click="handleLogout">
         Çıkış Yap
       </button>
-    </nav>
+    </div>
   </header>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import { RouterLink, useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { useAuth } from '@/composables/useAuth';
 
 const router = useRouter();
+const route = useRoute();
 const auth = useAuth();
-const isAuthenticated = computed(() => auth.state.isAuthenticated);
+
+const pageTitle = computed(() => {
+  const title = route.meta?.title;
+  return typeof title === 'string' && title.length > 0 ? title : 'Kontrol Paneli';
+});
 
 const handleLogout = () => {
   auth.logout();
@@ -33,58 +41,92 @@ const handleLogout = () => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.25rem 2rem;
-  background-color: #0f172a;
-  color: #f8fafc;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.2);
+  padding: 1.5rem 3rem 1.5rem 3rem;
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
 }
 
-.branding {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
+.header-titles {
+  display: grid;
+  gap: 0.25rem;
 }
 
-.logo {
+.eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: #64748b;
+}
+
+h1 {
+  margin: 0;
   font-size: 1.75rem;
+  color: #0f172a;
 }
 
-.title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.navigation {
+.header-actions {
   display: flex;
   align-items: center;
   gap: 1rem;
 }
 
-.navigation a {
-  color: inherit;
-  text-decoration: none;
-  font-weight: 500;
-  transition: opacity 0.2s ease-in-out;
+.user-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.4rem 0.9rem 0.4rem 0.5rem;
+  border-radius: 9999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
 }
 
-.navigation a:hover {
-  opacity: 0.75;
+.avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
+  color: #f8fafc;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
 }
 
 .logout {
-  background: transparent;
-  border: 1px solid rgba(248, 250, 252, 0.6);
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  border: none;
+  color: #f8fafc;
+  padding: 0.65rem 1.5rem;
   border-radius: 9999px;
-  padding: 0.4rem 1rem;
-  color: inherit;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  box-shadow: 0 12px 20px rgba(37, 99, 235, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .logout:hover {
-  background: #f8fafc;
-  color: #0f172a;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(37, 99, 235, 0.3);
+}
+
+.logout:active {
+  transform: translateY(0);
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.25);
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.25rem;
+    padding: 1.25rem 1.5rem;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 </style>

--- a/frontend/src/layouts/AuthenticatedLayout.vue
+++ b/frontend/src/layouts/AuthenticatedLayout.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Ana navigasyon">
+      <div class="sidebar-brand">
+        <span class="brand-icon" aria-hidden="true">📦</span>
+        <div>
+          <p class="brand-eyebrow">Envanter Yönetimi</p>
+          <h1>Kontrol Paneli</h1>
+        </div>
+      </div>
+
+      <nav class="sidebar-nav">
+        <section
+          v-for="(group, index) in navGroups"
+          :key="group.id"
+          class="nav-group"
+        >
+          <p v-if="group.label" class="group-label">{{ group.label }}</p>
+          <RouterLink
+            v-for="item in group.items"
+            :key="item.name"
+            :to="{ name: item.name }"
+            class="nav-link"
+            :class="{ active: activeRouteName === item.name }"
+          >
+            <span class="nav-label">{{ item.label }}</span>
+            <span v-if="item.caption" class="nav-caption">{{ item.caption }}</span>
+          </RouterLink>
+
+          <hr v-if="index !== navGroups.length - 1" class="group-divider" />
+        </section>
+      </nav>
+    </aside>
+
+    <div class="layout-main">
+      <AppHeader />
+      <div class="layout-content">
+        <RouterView />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { RouterLink, RouterView, useRoute } from 'vue-router';
+import AppHeader from '@/components/AppHeader.vue';
+
+const route = useRoute();
+const activeRouteName = computed(() => (route.name ?? '').toString());
+
+interface NavItem {
+  name: string;
+  label: string;
+  caption?: string;
+}
+
+interface NavGroup {
+  id: string;
+  label?: string;
+  items: NavItem[];
+}
+
+const navGroups = computed<NavGroup[]>(() => [
+  {
+    id: 'overview',
+    items: [
+      { name: 'home', label: 'Ana Sayfa', caption: 'Genel bakış ve özet' }
+    ]
+  },
+  {
+    id: 'tracking',
+    label: 'Takip Modülleri',
+    items: [
+      { name: 'inventory-tracking', label: 'Envanter Takip', caption: 'Donanım varlıkları' },
+      { name: 'license-tracking', label: 'Lisans Takip', caption: 'Yazılım yetkileri' },
+      { name: 'printer-tracking', label: 'Yazıcı Takip', caption: 'Yazıcı durumları' },
+      { name: 'stock-tracking', label: 'Stok Takip', caption: 'Giriş / çıkış işlemleri' }
+    ]
+  },
+  {
+    id: 'operations',
+    label: 'Operasyon',
+    items: [
+      { name: 'request-tracking', label: 'Talep Takip', caption: 'Açık talepler' },
+      { name: 'knowledge-base', label: 'Bilgi Bankası', caption: 'Prosedürler ve rehberler' },
+      { name: 'scrap-management', label: 'Hurdalar', caption: 'Hurda listesi' }
+    ]
+  },
+  {
+    id: 'account',
+    label: 'Hesap ve Yönetim',
+    items: [
+      { name: 'profile', label: 'Profil', caption: 'Kullanıcı bilgileri' },
+      { name: 'admin-panel', label: 'Admin Paneli', caption: 'Yetki ve roller' },
+      { name: 'records', label: 'Kayıtlar', caption: 'İşlem geçmişi' }
+    ]
+  }
+]);
+</script>
+
+<style scoped>
+.layout {
+  width: 100%;
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 0;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  padding: 2.5rem 2rem;
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.95), #0f172a 65%);
+  color: #e2e8f0;
+  box-shadow: inset -1px 0 0 rgba(148, 163, 184, 0.25);
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.sidebar-brand h1 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.brand-icon {
+  font-size: 2rem;
+}
+
+.brand-eyebrow {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  margin: 0;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  flex: 1;
+}
+
+.nav-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.group-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(226, 232, 240, 0.6);
+  margin: 0 0 0.75rem;
+}
+
+.nav-link {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  color: inherit;
+  text-decoration: none;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  transition: background 0.2s ease, border 0.2s ease, transform 0.2s ease;
+}
+
+.nav-link:hover {
+  background: rgba(30, 41, 59, 0.6);
+  border-color: rgba(148, 163, 184, 0.35);
+  transform: translateX(4px);
+}
+
+.nav-link.active {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.85), rgba(30, 64, 175, 0.85));
+  border-color: rgba(191, 219, 254, 0.6);
+  color: #f8fafc;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.35);
+}
+
+.nav-label {
+  font-weight: 600;
+  font-size: 0.98rem;
+}
+
+.nav-caption {
+  font-size: 0.78rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.group-divider {
+  border: none;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  margin: 1.25rem 0 0;
+}
+
+.layout-main {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.9) 0%, #f8fafc 55%, #e2e8f0 100%);
+}
+
+.layout-content {
+  flex: 1;
+  padding: 2.5rem 3rem 3rem;
+  overflow-y: auto;
+}
+
+@media (max-width: 1024px) {
+  .layout {
+    grid-template-columns: 240px 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    flex-direction: row;
+    overflow-x: auto;
+    padding: 1.5rem 1.25rem;
+    gap: 1.25rem;
+  }
+
+  .sidebar-brand {
+    margin: 0;
+    flex: 0 0 auto;
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+    gap: 1rem;
+  }
+
+  .nav-group {
+    min-width: 220px;
+  }
+
+  .group-divider {
+    display: none;
+  }
+}
+</style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,6 +1,17 @@
 import { createRouter, createWebHistory } from 'vue-router';
+import AuthenticatedLayout from '@/layouts/AuthenticatedLayout.vue';
 import LoginView from '@/views/LoginView.vue';
 import HomeView from '@/views/HomeView.vue';
+import InventoryTrackingView from '@/views/InventoryTrackingView.vue';
+import LicenseTrackingView from '@/views/LicenseTrackingView.vue';
+import PrinterTrackingView from '@/views/PrinterTrackingView.vue';
+import StockTrackingView from '@/views/StockTrackingView.vue';
+import RequestTrackingView from '@/views/RequestTrackingView.vue';
+import KnowledgeBaseView from '@/views/KnowledgeBaseView.vue';
+import ScrapManagementView from '@/views/ScrapManagementView.vue';
+import ProfileView from '@/views/ProfileView.vue';
+import AdminPanelView from '@/views/AdminPanelView.vue';
+import RecordsView from '@/views/RecordsView.vue';
 import { authGuard } from '@/router/middleware';
 
 const router = createRouter({
@@ -14,13 +25,80 @@ const router = createRouter({
       path: '/giris',
       name: 'login',
       component: LoginView,
-      meta: { layout: 'auth' }
+      meta: { layout: 'auth', title: 'Giriş Yap' }
     },
     {
-      path: '/ana-sayfa',
-      name: 'home',
-      component: HomeView,
-      meta: { requiresAuth: true }
+      path: '/',
+      component: AuthenticatedLayout,
+      meta: { requiresAuth: true },
+      children: [
+        {
+          path: 'ana-sayfa',
+          name: 'home',
+          component: HomeView,
+          meta: { title: 'Ana Sayfa', requiresAuth: true }
+        },
+        {
+          path: 'envanter-takip',
+          name: 'inventory-tracking',
+          component: InventoryTrackingView,
+          meta: { title: 'Envanter Takip', requiresAuth: true }
+        },
+        {
+          path: 'lisans-takip',
+          name: 'license-tracking',
+          component: LicenseTrackingView,
+          meta: { title: 'Lisans Takip', requiresAuth: true }
+        },
+        {
+          path: 'yazici-takip',
+          name: 'printer-tracking',
+          component: PrinterTrackingView,
+          meta: { title: 'Yazıcı Takip', requiresAuth: true }
+        },
+        {
+          path: 'stok-takip',
+          name: 'stock-tracking',
+          component: StockTrackingView,
+          meta: { title: 'Stok Takip', requiresAuth: true }
+        },
+        {
+          path: 'talep-takip',
+          name: 'request-tracking',
+          component: RequestTrackingView,
+          meta: { title: 'Talep Takip', requiresAuth: true }
+        },
+        {
+          path: 'bilgi-bankasi',
+          name: 'knowledge-base',
+          component: KnowledgeBaseView,
+          meta: { title: 'Bilgi Bankası', requiresAuth: true }
+        },
+        {
+          path: 'hurdalar',
+          name: 'scrap-management',
+          component: ScrapManagementView,
+          meta: { title: 'Hurdalar', requiresAuth: true }
+        },
+        {
+          path: 'profil',
+          name: 'profile',
+          component: ProfileView,
+          meta: { title: 'Profil', requiresAuth: true }
+        },
+        {
+          path: 'admin-paneli',
+          name: 'admin-panel',
+          component: AdminPanelView,
+          meta: { title: 'Admin Paneli', requiresAuth: true }
+        },
+        {
+          path: 'kayitlar',
+          name: 'records',
+          component: RecordsView,
+          meta: { title: 'Kayıtlar', requiresAuth: true }
+        }
+      ]
     },
     {
       path: '/:pathMatch(.*)*',

--- a/frontend/src/views/AdminPanelView.vue
+++ b/frontend/src/views/AdminPanelView.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="page-section" aria-labelledby="admin-title">
+    <header class="page-header">
+      <h1 id="admin-title">Admin Paneli</h1>
+      <p class="page-intro">
+        Sistem rollerini, yetkileri ve uygulama ayarlarını yönetin. Denetim ihtiyaçları için merkezi
+        bir yönetim alanı sağlar.
+      </p>
+    </header>
+
+    <div class="page-panels">
+      <article class="page-card">
+        <h2>Yönetim Araçları</h2>
+        <ul>
+          <li>Rol bazlı yetkilendirme ve erişim matrisi.</li>
+          <li>Modüllere özel yapılandırma ayarları.</li>
+          <li>Bakım modunda duyuru ve kapatma planları.</li>
+        </ul>
+      </article>
+
+      <article class="page-card">
+        <h2>Denetim ve Güvenlik</h2>
+        <p>
+          Kayıtlar modülü ile entegre edilen audit log'lar sayesinde kritik işlemleri izleyin. Profil
+          bölümünden gelen güvenlik ayarları ile koordineli çalışır.
+        </p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-section {
+  display: grid;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.page-intro {
+  margin: 0;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-panels {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-card {
+  padding: 2.25rem;
+  border-radius: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.page-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.page-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: #475569;
+}
+</style>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,59 +1,119 @@
 <template>
-  <section class="home-wrapper" aria-labelledby="home-title">
-    <header>
+  <section class="page-section" aria-labelledby="home-title">
+    <header class="page-header">
       <h1 id="home-title">Ana Sayfa</h1>
-      <p class="home-subtitle">
-        Hoş geldiniz! Bu alan ileride oluşturacağımız diğer modüller için başlangıç noktasıdır.
+      <p class="page-intro">
+        Envanter yönetim paneline hoş geldiniz. Soldaki menüden takip modülleri, talepler ve
+        yönetim araçlarına erişebilir; aşağıdaki özet alanından son durumunuzu inceleyebilirsiniz.
       </p>
     </header>
 
-    <article class="home-card">
-      <h2>Sonraki Adımlar</h2>
-      <ul>
-        <li>Yeni sayfalar ekleyip router üzerinden bağlantı kurabilirsiniz.</li>
-        <li>Gerçek bir API ile kimlik doğrulaması entegre edebilirsiniz.</li>
-        <li>Dashboard, raporlar veya ayarlar gibi alt sayfalar oluşturabilirsiniz.</li>
-      </ul>
-    </article>
+    <div class="page-grid" role="list">
+      <article class="summary-card" role="listitem">
+        <h2>Takip Modülleri</h2>
+        <p>
+          Envanter, lisans, yazıcı ve stok kayıtlarını tek noktadan yönetin. Her modülde çalışma
+          listeleri, durum göstergeleri ve filtreleme seçenekleri planlanmıştır.
+        </p>
+        <RouterLink class="summary-link" :to="{ name: 'inventory-tracking' }">
+          Envanter modülüne git
+        </RouterLink>
+      </article>
+
+      <article class="summary-card" role="listitem">
+        <h2>Operasyon</h2>
+        <p>
+          Talep kayıtlarını izleyin, bilgi bankasından prosedürlere ulaşın ve hurda listesi ile geri
+          dönüşüm süreçlerini takip edin.
+        </p>
+        <RouterLink class="summary-link" :to="{ name: 'request-tracking' }">
+          Talepleri görüntüle
+        </RouterLink>
+      </article>
+
+      <article class="summary-card" role="listitem">
+        <h2>Yönetim</h2>
+        <p>
+          Profil ayarlarınızı güncelleyin, admin panelinde yetkileri yönetin ve yapılan tüm işlem
+          kayıtlarına ulaşın.
+        </p>
+        <RouterLink class="summary-link" :to="{ name: 'admin-panel' }">
+          Yönetim araçlarını aç
+        </RouterLink>
+      </article>
+    </div>
   </section>
 </template>
 
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+</script>
+
 <style scoped>
-.home-wrapper {
-  width: min(720px, 100%);
-  margin: 0 auto;
+.page-section {
   display: grid;
-  gap: 2rem;
+  gap: 2.5rem;
   color: #0f172a;
 }
 
-header h1 {
+.page-header h1 {
+  margin: 0 0 0.75rem;
   font-size: 2.25rem;
-  margin-bottom: 0.5rem;
 }
 
-.home-subtitle {
-  color: #475569;
+.page-intro {
+  margin: 0;
+  max-width: 720px;
   font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
 }
 
-.home-card {
+.page-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.summary-card {
   padding: 2rem;
   border-radius: 20px;
   background: #ffffff;
-  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.home-card h2 {
-  font-size: 1.5rem;
-  margin-bottom: 1rem;
-}
-
-.home-card ul {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.08);
   display: grid;
-  gap: 0.75rem;
-  list-style: disc inside;
-  color: #1e293b;
+  gap: 1rem;
+  min-height: 220px;
+}
+
+.summary-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.summary-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.summary-link {
+  align-self: flex-end;
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.summary-link::after {
+  content: '›';
+  font-size: 1.1rem;
+  transition: transform 0.2s ease;
+}
+
+.summary-link:hover::after {
+  transform: translateX(4px);
 }
 </style>

--- a/frontend/src/views/InventoryTrackingView.vue
+++ b/frontend/src/views/InventoryTrackingView.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="page-section" aria-labelledby="inventory-title">
+    <header class="page-header">
+      <h1 id="inventory-title">Envanter Takip</h1>
+      <p class="page-intro">
+        Tüm donanım envanterini tek bir ekrandan yönetin. Cihaz kimlikleri, zimmet bilgileri ve
+        bakım planlarıyla tam görünürlük sağlayın.
+      </p>
+    </header>
+
+    <div class="page-panels">
+      <article class="page-card">
+        <h2>Planlanan Özellikler</h2>
+        <ul>
+          <li>Lokasyona, departmana veya sorumlu kişiye göre filtreleme.</li>
+          <li>Garanti ve bakım tarihleri için otomatik hatırlatmalar.</li>
+          <li>Excel/CSV içeri aktarma ve dışa aktarma seçenekleri.</li>
+        </ul>
+      </article>
+
+      <article class="page-card">
+        <h2>Hızlı Notlar</h2>
+        <p>
+          Envanter modülünü, stok giriş/çıkış kayıtlarıyla entegre ederek cihaz hareketlerini takip
+          edin. Talep modülü ile bağlantı kurup onay süreçlerini aynı yerden yönetin.
+        </p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-section {
+  display: grid;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.page-intro {
+  margin: 0;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-panels {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-card {
+  padding: 2.25rem;
+  border-radius: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.page-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.page-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: #475569;
+}
+</style>

--- a/frontend/src/views/KnowledgeBaseView.vue
+++ b/frontend/src/views/KnowledgeBaseView.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="page-section" aria-labelledby="knowledge-title">
+    <header class="page-header">
+      <h1 id="knowledge-title">Bilgi Bankası</h1>
+      <p class="page-intro">
+        Prosedürler, sık sorulan sorular ve ekip rehberleri burada toplanacak. Kullanıcılar
+        gereksinim duydukları dokümana hızlıca ulaşabilecek.
+      </p>
+    </header>
+
+    <div class="page-panels">
+      <article class="page-card">
+        <h2>İçerik Yapısı</h2>
+        <ul>
+          <li>Kategori bazlı içerik yönetimi (envanter, lisans, destek vb.).</li>
+          <li>Versiyonlama ve yayınlama süreçleri.</li>
+          <li>Arama ve etiketleme altyapısı.</li>
+        </ul>
+      </article>
+
+      <article class="page-card">
+        <h2>İlişkili Modüller</h2>
+        <p>
+          Talep kayıtları ile bilgi bankası makalelerini bağlayarak çözüm önerilerini otomatik
+          önerin. Admin panelinden editör izinlerini yönetin.
+        </p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-section {
+  display: grid;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.page-intro {
+  margin: 0;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-panels {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-card {
+  padding: 2.25rem;
+  border-radius: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.page-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.page-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: #475569;
+}
+</style>

--- a/frontend/src/views/LicenseTrackingView.vue
+++ b/frontend/src/views/LicenseTrackingView.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="page-section" aria-labelledby="license-title">
+    <header class="page-header">
+      <h1 id="license-title">Lisans Takip</h1>
+      <p class="page-intro">
+        Yazılım lisanslarını merkezileştirin. Sona eren veya yeni satın alınan lisansları, kullanım
+        haklarını ve atamaları buradan izleyin.
+      </p>
+    </header>
+
+    <div class="page-panels">
+      <article class="page-card">
+        <h2>Kontrol Listesi</h2>
+        <ul>
+          <li>Lisans tipine göre (per seat, per device vb.) görünürlük.</li>
+          <li>Uyarı süresi tanımlayarak yaklaşan yenilemeleri takip edin.</li>
+          <li>Aktif kullanıcı eşleştirmesi ve boşta kalan lisans raporu.</li>
+        </ul>
+      </article>
+
+      <article class="page-card">
+        <h2>Önerilen Entegrasyonlar</h2>
+        <p>
+          Envanter modülündeki cihazlarla lisansları eşleştirerek hangi uygulamanın hangi makinede
+          çalıştığını görün. Talep modülü ile lisans taleplerini otomatik onay akışına dahil edin.
+        </p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-section {
+  display: grid;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.page-intro {
+  margin: 0;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-panels {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-card {
+  padding: 2.25rem;
+  border-radius: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.page-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.page-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: #475569;
+}
+</style>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,46 +1,48 @@
 <template>
-  <section class="login-wrapper" aria-labelledby="login-title">
-    <h1 id="login-title">Hesabınıza giriş yapın</h1>
-    <p class="login-subtitle">
-      Ana sayfaya ulaşmak için kullanıcı adı ve şifrenizi girin.
-      <span class="hint">(admin / 123456)</span>
-    </p>
-
-    <form class="login-form" @submit.prevent="handleSubmit" novalidate>
-      <label class="form-field">
-        <span>Kullanıcı Adı</span>
-        <input
-          v-model.trim="form.username"
-          type="text"
-          name="username"
-          autocomplete="username"
-          required
-          placeholder="örn. admin"
-        />
-      </label>
-
-      <label class="form-field">
-        <span>Şifre</span>
-        <input
-          v-model="form.password"
-          type="password"
-          name="password"
-          autocomplete="current-password"
-          required
-          placeholder="örn. 123456"
-        />
-      </label>
-
-      <p v-if="error" class="form-error" role="alert">
-        {{ error }}
+  <div class="login-page">
+    <section class="login-wrapper" aria-labelledby="login-title">
+      <h1 id="login-title">Hesabınıza giriş yapın</h1>
+      <p class="login-subtitle">
+        Ana sayfaya ulaşmak için kullanıcı adı ve şifrenizi girin.
+        <span class="hint">(admin / 123456)</span>
       </p>
 
-      <button type="submit" class="submit-button" :disabled="isSubmitting">
-        <span v-if="!isSubmitting">Giriş Yap</span>
-        <span v-else>Kontrol ediliyor...</span>
-      </button>
-    </form>
-  </section>
+      <form class="login-form" @submit.prevent="handleSubmit" novalidate>
+        <label class="form-field">
+          <span>Kullanıcı Adı</span>
+          <input
+            v-model.trim="form.username"
+            type="text"
+            name="username"
+            autocomplete="username"
+            required
+            placeholder="örn. admin"
+          />
+        </label>
+
+        <label class="form-field">
+          <span>Şifre</span>
+          <input
+            v-model="form.password"
+            type="password"
+            name="password"
+            autocomplete="current-password"
+            required
+            placeholder="örn. 123456"
+          />
+        </label>
+
+        <p v-if="error" class="form-error" role="alert">
+          {{ error }}
+        </p>
+
+        <button type="submit" class="submit-button" :disabled="isSubmitting">
+          <span v-if="!isSubmitting">Giriş Yap</span>
+          <span v-else>Kontrol ediliyor...</span>
+        </button>
+      </form>
+    </section>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -92,18 +94,28 @@ const handleSubmit = () => {
 </script>
 
 <style scoped>
+.login-page {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem 3rem;
+  background: linear-gradient(180deg, rgba(241, 245, 249, 0.65) 0%, rgba(255, 255, 255, 0.9) 100%);
+}
+
 .login-wrapper {
   width: min(420px, 100%);
-  padding: 2.5rem 2rem;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
-  backdrop-filter: blur(6px);
+  padding: 2.75rem 2.25rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(8px);
   text-align: center;
 }
 
 .login-wrapper h1 {
-  font-size: 1.75rem;
+  font-size: 1.9rem;
   margin-bottom: 0.75rem;
   color: #0f172a;
 }
@@ -111,7 +123,7 @@ const handleSubmit = () => {
 .login-subtitle {
   margin-bottom: 2rem;
   color: #475569;
-  line-height: 1.5;
+  line-height: 1.6;
 }
 
 .hint {
@@ -136,7 +148,7 @@ const handleSubmit = () => {
 
 .form-field input {
   width: 100%;
-  padding: 0.75rem 1rem;
+  padding: 0.85rem 1rem;
   border-radius: 12px;
   border: 1px solid #cbd5f5;
   background-color: #f8fafc;
@@ -159,7 +171,7 @@ const handleSubmit = () => {
 
 .submit-button {
   width: 100%;
-  padding: 0.85rem 1rem;
+  padding: 0.95rem 1rem;
   border-radius: 9999px;
   border: none;
   background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);

--- a/frontend/src/views/PrinterTrackingView.vue
+++ b/frontend/src/views/PrinterTrackingView.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="page-section" aria-labelledby="printer-title">
+    <header class="page-header">
+      <h1 id="printer-title">Yazıcı Takip</h1>
+      <p class="page-intro">
+        Yazıcı ve çok fonksiyonlu cihazlarınızın durumunu, sarf malzeme seviyelerini ve bakım
+        ihtiyaçlarını takip edin.
+      </p>
+    </header>
+
+    <div class="page-panels">
+      <article class="page-card">
+        <h2>Takip Edilecek Başlıklar</h2>
+        <ul>
+          <li>Toner / mürekkep seviyelerini renk bazlı gösterimler ile izleyin.</li>
+          <li>Arıza kayıtlarını talep modülü ile ilişkilendirerek aksiyon alın.</li>
+          <li>Periyodik bakım ajandası oluşturarak servis ziyaretlerini planlayın.</li>
+        </ul>
+      </article>
+
+      <article class="page-card">
+        <h2>Son Durum Özeti</h2>
+        <p>
+          Bu alan, cihaz çevrim içi/çevrim dışı durumlarını, bekleyen sarf malzeme siparişlerini ve
+          kritik uyarıları göstermesi için tasarlanmıştır.
+        </p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-section {
+  display: grid;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.page-intro {
+  margin: 0;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-panels {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-card {
+  padding: 2.25rem;
+  border-radius: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.page-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.page-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: #475569;
+}
+</style>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -1,0 +1,85 @@
+<template>
+  <section class="page-section" aria-labelledby="profile-title">
+    <header class="page-header">
+      <h1 id="profile-title">Profil</h1>
+      <p class="page-intro">
+        Kullanıcı bilgilerinizi, bildirim tercihlerinizi ve oturum geçmişinizi yönetin.
+      </p>
+    </header>
+
+    <div class="page-panels">
+      <article class="page-card">
+        <h2>Hesap Bilgileri</h2>
+        <p>
+          Bu alanda ad, soyad, e-posta ve iletişim bilgilerinizi güncelleyebilirsiniz. Şifre
+          değiştirme ve iki faktörlü doğrulama ayarları da burada yer alacaktır.
+        </p>
+      </article>
+
+      <article class="page-card">
+        <h2>Aktivite Özeti</h2>
+        <ul>
+          <li>Son oturum açma tarihleri ve IP adresleri.</li>
+          <li>Yapılan kritik işlemler için bildirim geçmişi.</li>
+          <li>Bağlı cihazlar ve güvenlik kontrolleri.</li>
+        </ul>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-section {
+  display: grid;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.page-intro {
+  margin: 0;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-panels {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-card {
+  padding: 2.25rem;
+  border-radius: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.page-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.page-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: #475569;
+}
+</style>

--- a/frontend/src/views/RecordsView.vue
+++ b/frontend/src/views/RecordsView.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="page-section" aria-labelledby="records-title">
+    <header class="page-header">
+      <h1 id="records-title">Kayıtlar</h1>
+      <p class="page-intro">
+        Tüm modüllerde gerçekleşen işlemlerin denetim geçmişini görüntüleyin. Filtreler ve raporlar
+        sayesinde izlenebilirliği artırın.
+      </p>
+    </header>
+
+    <div class="page-panels">
+      <article class="page-card">
+        <h2>Raporlama</h2>
+        <ul>
+          <li>Tarih, kullanıcı, modül ve işlem tipine göre filtreleme.</li>
+          <li>Excel/PDF dışa aktarma ve planlanmış rapor gönderimi.</li>
+          <li>Riskli işlem uyarıları ve otomatik bildirimler.</li>
+        </ul>
+      </article>
+
+      <article class="page-card">
+        <h2>İlgili Modüller</h2>
+        <p>
+          Admin panelinden yetki değişiklikleri, talep modülündeki onaylar ve stok hareketleri
+          burada izlenebilir olacak.
+        </p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-section {
+  display: grid;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.page-intro {
+  margin: 0;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-panels {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-card {
+  padding: 2.25rem;
+  border-radius: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.page-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.page-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: #475569;
+}
+</style>

--- a/frontend/src/views/RequestTrackingView.vue
+++ b/frontend/src/views/RequestTrackingView.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="page-section" aria-labelledby="request-title">
+    <header class="page-header">
+      <h1 id="request-title">Talep Takip</h1>
+      <p class="page-intro">
+        Kullanıcılardan gelen envanter, lisans veya destek taleplerini yönetin. Onay akışları ve SLA
+        süreleri bu modülde takip edilecektir.
+      </p>
+    </header>
+
+    <div class="page-panels">
+      <article class="page-card">
+        <h2>Bekleyen Görevler</h2>
+        <ul>
+          <li>Onay bekleyen talepler için bildirim sistemi.</li>
+          <li>Talepleri tipine göre sınıflandırma (envanter, lisans, destek).</li>
+          <li>İş akışı adımlarını özelleştirilebilir hale getirme.</li>
+        </ul>
+      </article>
+
+      <article class="page-card">
+        <h2>İş Birlikleri</h2>
+        <p>
+          Stok ve envanter modülleri ile doğrudan bağlantı kurarak onaylanan taleplerin otomatik
+          olarak stok düşümü yapmasını sağlayın.
+        </p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-section {
+  display: grid;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.page-intro {
+  margin: 0;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-panels {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-card {
+  padding: 2.25rem;
+  border-radius: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.page-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.page-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: #475569;
+}
+</style>

--- a/frontend/src/views/ScrapManagementView.vue
+++ b/frontend/src/views/ScrapManagementView.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="page-section" aria-labelledby="scrap-title">
+    <header class="page-header">
+      <h1 id="scrap-title">Hurdalar</h1>
+      <p class="page-intro">
+        Hurdaya ayrılması planlanan veya süreci devam eden ekipmanları listeleyin. Onay süreçleri ve
+        elden çıkarma belgeleri bu bölümde tutulacaktır.
+      </p>
+    </header>
+
+    <div class="page-panels">
+      <article class="page-card">
+        <h2>Takip Başlıkları</h2>
+        <ul>
+          <li>Hurda nedenleri ve finansal etkilerinin kaydı.</li>
+          <li>Yetkili onay zincirlerinin takibi.</li>
+          <li>Fotoğraf ve belge ekleri için arşiv alanı.</li>
+        </ul>
+      </article>
+
+      <article class="page-card">
+        <h2>Entegrasyon Senaryoları</h2>
+        <p>
+          Envanter kartlarını hurda durumuna geçirerek stoktan düşmesini sağlayın. Kayıtlar modülü ile
+          birlikte tüm geçmiş işlemleri raporlayın.
+        </p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-section {
+  display: grid;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.page-intro {
+  margin: 0;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-panels {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-card {
+  padding: 2.25rem;
+  border-radius: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.page-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.page-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: #475569;
+}
+</style>

--- a/frontend/src/views/StockTrackingView.vue
+++ b/frontend/src/views/StockTrackingView.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="page-section" aria-labelledby="stock-title">
+    <header class="page-header">
+      <h1 id="stock-title">Stok Takip</h1>
+      <p class="page-intro">
+        Depo stoklarınızı giriş ve çıkış hareketleriyle izleyin. Minimum stok seviyeleri ve kritik
+        uyarılar bu alanda listelenecektir.
+      </p>
+    </header>
+
+    <div class="page-panels">
+      <article class="page-card">
+        <h2>Modül Özeti</h2>
+        <ul>
+          <li>Stok kartları için kategori, tedarikçi ve maliyet bilgileri.</li>
+          <li>Talep modülüyle entegre edilen rezervasyon akışı.</li>
+          <li>Otomatik depo sayımları ve mutabakat raporları.</li>
+        </ul>
+      </article>
+
+      <article class="page-card">
+        <h2>Gelecek Geliştirmeler</h2>
+        <p>
+          Stok seviyeleri için görsel panolar, barkod/QR kod desteği ve çoklu depo yönetimi
+          planlanmaktadır.
+        </p>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.page-section {
+  display: grid;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.page-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+}
+
+.page-intro {
+  margin: 0;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-panels {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-card {
+  padding: 2.25rem;
+  border-radius: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.page-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.page-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.page-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: #475569;
+}
+</style>


### PR DESCRIPTION
## Summary
- replace the root app shell with a simple router outlet and move authenticated chrome into a dedicated layout
- add a sidebar-driven authenticated dashboard layout with grouped navigation and refreshed header styling
- scaffold individual module pages for inventory, licenses, printers, stock, requests, knowledge base, scrap, profile, admin, and records views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f0e2434c7c832bb70155c1fd8bc6b6