### PR TITLE
Enhance operations pages with linked workflows

### DIFF
--- a/frontend/src/views/AdminPanelView.vue
+++ b/frontend/src/views/AdminPanelView.vue
@@ -1,39 +1,253 @@
 <template>
   <section class="page-section" aria-labelledby="admin-title">
     <header class="page-header">
-      <h1 id="admin-title">Admin Paneli</h1>
-      <p class="page-intro">
-        Sistem rollerini, yetkileri ve uygulama ayarlarını yönetin. Denetim ihtiyaçları için merkezi
-        bir yönetim alanı sağlar.
-      </p>
+      <div>
+        <h1 id="admin-title">Admin Paneli</h1>
+        <p class="page-intro">
+          Kullanıcıları yönet, ürün kataloglarını güncelle ve bağlantı yapılandırmalarını düzenle.
+          Admin paneli tüm modüllerin ortak verilerinin tutulduğu merkezi yönetim alanıdır.
+        </p>
+      </div>
+      <RouterLink :to="{ name: 'records' }" class="header-link">
+        Kayıt geçmişini aç
+      </RouterLink>
     </header>
 
-    <div class="page-panels">
-      <article class="page-card">
-        <h2>Yönetim Araçları</h2>
-        <ul>
-          <li>Rol bazlı yetkilendirme ve erişim matrisi.</li>
-          <li>Modüllere özel yapılandırma ayarları.</li>
-          <li>Bakım modunda duyuru ve kapatma planları.</li>
-        </ul>
+    <div class="admin-grid">
+      <article class="admin-card" aria-labelledby="users-title">
+        <header>
+          <h2 id="users-title">Kullanıcılar</h2>
+          <p>Rolleri ve erişim düzeyleri ile birlikte aktif kullanıcı listesi.</p>
+        </header>
+        <table class="admin-table">
+          <thead>
+            <tr>
+              <th scope="col">Kullanıcı</th>
+              <th scope="col">Rol</th>
+              <th scope="col">Modül</th>
+              <th scope="col">Durum</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="user in users" :key="user.username">
+              <td>
+                <span class="user-name">{{ user.fullName }}</span>
+                <span class="user-username">{{ user.username }}</span>
+              </td>
+              <td>{{ user.role }}</td>
+              <td>{{ user.modules.join(', ') }}</td>
+              <td>{{ user.state }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <footer>
+          <RouterLink :to="{ name: 'profile' }" class="card-link">
+            Profil bilgilerini düzenle
+          </RouterLink>
+        </footer>
       </article>
 
-      <article class="page-card">
-        <h2>Denetim ve Güvenlik</h2>
-        <p>
-          Kayıtlar modülü ile entegre edilen audit log'lar sayesinde kritik işlemleri izleyin. Profil
-          bölümünden gelen güvenlik ayarları ile koordineli çalışır.
-        </p>
+      <article class="admin-card" aria-labelledby="products-title">
+        <header>
+          <h2 id="products-title">Ürün Kütüphanesi</h2>
+          <p>Talep ve envanter modüllerinde kullanılacak ortak ürün listeleri.</p>
+        </header>
+        <ul class="product-list">
+          <li v-for="product in products" :key="product.id">
+            <div>
+              <p class="product-title">{{ product.title }}</p>
+              <p class="product-meta">{{ product.category }} • {{ product.count }} kayıt</p>
+              <p class="product-note">{{ product.note }}</p>
+            </div>
+            <RouterLink :to="{ name: product.routeName }" class="product-link">
+              {{ product.linkLabel }}
+            </RouterLink>
+          </li>
+        </ul>
+        <footer>
+          <RouterLink :to="{ name: 'request-tracking' }" class="card-link">
+            Talep açılış formunu güncelle
+          </RouterLink>
+        </footer>
+      </article>
+
+      <article class="admin-card" aria-labelledby="integrations-title">
+        <header>
+          <h2 id="integrations-title">Bağlantılar</h2>
+          <p>LDAP ve diğer entegrasyonlar ile sistemler arası senkronizasyonu yapılandır.</p>
+        </header>
+        <ul class="integration-list">
+          <li v-for="integration in integrations" :key="integration.id">
+            <div>
+              <p class="integration-title">{{ integration.title }}</p>
+              <p class="integration-note">{{ integration.note }}</p>
+            </div>
+            <RouterLink :to="{ name: integration.routeName }" class="integration-link">
+              {{ integration.linkLabel }}
+            </RouterLink>
+          </li>
+        </ul>
+        <footer>
+          <RouterLink :to="{ name: 'knowledge-base' }" class="card-link">
+            Bağlantı yönergelerini aç
+          </RouterLink>
+        </footer>
       </article>
     </div>
+
+    <article class="workflow-card">
+      <h2>Yönetim Döngüsü</h2>
+      <ol class="workflow-steps">
+        <li>
+          Kullanıcı rolü atandığında ilgili bildirimler
+          <RouterLink :to="{ name: 'profile' }">Profil</RouterLink> sayfasında görüntülenir.
+        </li>
+        <li>
+          Ürün kütüphanesine eklenen kayıtlar otomatik olarak
+          <RouterLink :to="{ name: 'request-tracking' }">Talep Takip</RouterLink> ve
+          <RouterLink :to="{ name: 'inventory-tracking' }">Envanter Takip</RouterLink>
+          formlarına yansır.
+        </li>
+        <li>
+          LDAP ayarları güncellendiğinde sonuçlar
+          <RouterLink :to="{ name: 'records' }">Kayıtlar</RouterLink> modülünde loglanır ve bilgi
+          bankasına aktarılır.
+        </li>
+      </ol>
+    </article>
   </section>
 </template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+
+type RouteName =
+  | 'inventory-tracking'
+  | 'request-tracking'
+  | 'printer-tracking'
+  | 'license-tracking'
+  | 'profile'
+  | 'knowledge-base'
+  | 'records';
+
+interface UserItem {
+  username: string;
+  fullName: string;
+  role: string;
+  modules: string[];
+  state: string;
+}
+
+interface ProductItem {
+  id: string;
+  title: string;
+  category: string;
+  count: number;
+  note: string;
+  routeName: RouteName;
+  linkLabel: string;
+}
+
+interface IntegrationItem {
+  id: string;
+  title: string;
+  note: string;
+  routeName: RouteName;
+  linkLabel: string;
+}
+
+const users: UserItem[] = [
+  {
+    username: 'syilmaz',
+    fullName: 'Selin Yılmaz',
+    role: 'Talep Onaycısı',
+    modules: ['Talep', 'Hurda'],
+    state: 'Aktif'
+  },
+  {
+    username: 'byildiz',
+    fullName: 'Baran Yıldız',
+    role: 'Sistem Yöneticisi',
+    modules: ['Admin', 'LDAP'],
+    state: 'Aktif'
+  },
+  {
+    username: 'ekara',
+    fullName: 'Ebru Kara',
+    role: 'Envanter Uzmanı',
+    modules: ['Envanter', 'Stok'],
+    state: 'İzinli'
+  }
+];
+
+const products: ProductItem[] = [
+  {
+    id: '1',
+    title: 'BT Donanımları',
+    category: 'Envanter',
+    count: 128,
+    note: 'Dizüstü, masaüstü, monitör ve çevre birimleri listesi.',
+    routeName: 'inventory-tracking',
+    linkLabel: 'Envantere git'
+  },
+  {
+    id: '2',
+    title: 'Yazılım Lisansları',
+    category: 'Lisans',
+    count: 86,
+    note: 'Adobe, Microsoft 365 ve özel uygulama lisansları.',
+    routeName: 'license-tracking',
+    linkLabel: 'Lisansları aç'
+  },
+  {
+    id: '3',
+    title: 'Yazıcı Sarf Malzemeleri',
+    category: 'Stok',
+    count: 42,
+    note: 'Toner, drum ve bakım kitleri için standart kodlar.',
+    routeName: 'printer-tracking',
+    linkLabel: 'Yazıcı takibini görüntüle'
+  }
+];
+
+const integrations: IntegrationItem[] = [
+  {
+    id: '1',
+    title: 'Kurumsal LDAP',
+    note: 'Active Directory ile kullanıcı senkronizasyonu.',
+    routeName: 'records',
+    linkLabel: 'Logları incele'
+  },
+  {
+    id: '2',
+    title: 'Tek oturum açma (SSO)',
+    note: 'Portal girişleri için SSO sağlayıcı ayarları.',
+    routeName: 'profile',
+    linkLabel: 'Kullanıcı erişimini gör'
+  },
+  {
+    id: '3',
+    title: 'Talep formu API',
+    note: 'Dış sistemlerden talep açılışına izin veren bağlantı.',
+    routeName: 'request-tracking',
+    linkLabel: 'Talepleri izle'
+  }
+];
+</script>
 
 <style scoped>
 .page-section {
   display: grid;
   gap: 2.5rem;
   color: #0f172a;
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .page-header h1 {
@@ -43,44 +257,158 @@
 
 .page-intro {
   margin: 0;
-  max-width: 720px;
+  max-width: 760px;
   font-size: 1.05rem;
   color: #475569;
   line-height: 1.6;
 }
 
-.page-panels {
+.header-link {
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  background: #0f172a;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.admin-grid {
   display: grid;
   gap: 1.75rem;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
-.page-card {
-  padding: 2.25rem;
+.admin-card {
+  padding: 2rem;
   border-radius: 22px;
-  background: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  background: #ffffff;
   display: grid;
-  gap: 1.1rem;
+  gap: 1.5rem;
 }
 
-.page-card h2 {
+.admin-card header h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.35rem;
+}
+
+.admin-card header p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.admin-table th {
+  color: #475569;
+  font-weight: 600;
+  background: rgba(226, 232, 240, 0.35);
+}
+
+.user-name {
+  display: block;
+  font-weight: 600;
+}
+
+.user-username {
+  display: block;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.card-link {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.product-list,
+.integration-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.product-list li,
+.integration-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: rgba(241, 245, 249, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.product-title,
+.integration-title {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+}
+
+.product-meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.product-note,
+.integration-note {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.product-link,
+.integration-link {
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.workflow-card {
+  padding: 2.5rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(14, 165, 233, 0.08));
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.workflow-card h2 {
   margin: 0;
   font-size: 1.4rem;
 }
 
-.page-card p {
-  margin: 0;
-  color: #475569;
-  line-height: 1.6;
-}
-
-.page-card ul {
+.workflow-steps {
   margin: 0;
   padding-left: 1.2rem;
   display: grid;
-  gap: 0.65rem;
-  color: #475569;
+  gap: 0.75rem;
+  color: #1f2937;
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  .product-list li,
+  .integration-list li {
+    flex-direction: column;
+  }
 }
 </style>

--- a/frontend/src/views/KnowledgeBaseView.vue
+++ b/frontend/src/views/KnowledgeBaseView.vue
@@ -1,39 +1,198 @@
 <template>
   <section class="page-section" aria-labelledby="knowledge-title">
     <header class="page-header">
-      <h1 id="knowledge-title">Bilgi Bankası</h1>
-      <p class="page-intro">
-        Prosedürler, sık sorulan sorular ve ekip rehberleri burada toplanacak. Kullanıcılar
-        gereksinim duydukları dokümana hızlıca ulaşabilecek.
-      </p>
+      <div>
+        <h1 id="knowledge-title">Bilgi Bankası</h1>
+        <p class="page-intro">
+          Ekip içi dokümanlar, prosedürler ve hızlı rehberler burada tutulur. Herkesin erişebildiği
+          merkezi bilgi havuzu sayesinde talep süreci ve operasyonlar tek kaynaktan yönetilir.
+        </p>
+      </div>
+
+      <div class="page-tools">
+        <div class="search-placeholder" role="search">
+          <span aria-hidden="true">🔍</span>
+          <div>
+            <p class="search-title">Başlık veya etikete göre ara</p>
+            <p class="search-caption">Örn: "Hurda prosedürü" ya da "ldap bağlanma"</p>
+          </div>
+        </div>
+        <RouterLink :to="{ name: 'admin-panel' }" class="page-tool-link">
+          Yetkilendirmeleri düzenle
+        </RouterLink>
+      </div>
     </header>
 
-    <div class="page-panels">
-      <article class="page-card">
-        <h2>İçerik Yapısı</h2>
-        <ul>
-          <li>Kategori bazlı içerik yönetimi (envanter, lisans, destek vb.).</li>
-          <li>Versiyonlama ve yayınlama süreçleri.</li>
-          <li>Arama ve etiketleme altyapısı.</li>
+    <div class="knowledge-grid">
+      <article
+        v-for="category in categories"
+        :key="category.id"
+        class="knowledge-card"
+      >
+        <header class="card-header">
+          <span class="card-icon" aria-hidden="true">{{ category.icon }}</span>
+          <div>
+            <h2>{{ category.title }}</h2>
+            <p>{{ category.summary }}</p>
+          </div>
+        </header>
+        <ul class="article-list">
+          <li v-for="article in category.articles" :key="article">
+            {{ article }}
+          </li>
         </ul>
+        <footer class="card-footer">
+          <RouterLink :to="{ name: category.routeName }" class="card-link">
+            {{ category.linkLabel }}
+          </RouterLink>
+          <p>{{ category.helperText }}</p>
+        </footer>
       </article>
 
-      <article class="page-card">
-        <h2>İlişkili Modüller</h2>
-        <p>
-          Talep kayıtları ile bilgi bankası makalelerini bağlayarak çözüm önerilerini otomatik
-          önerin. Admin panelinden editör izinlerini yönetin.
-        </p>
-      </article>
+      <aside class="knowledge-side">
+        <section class="callout" aria-labelledby="callout-title">
+          <h2 id="callout-title">Talep Yönetimi ile Entegrasyon</h2>
+          <p>
+            Talep açan kullanıcılar ilgili dokümanları otomatik olarak görür. Örneğin hurda talepleri
+            için <RouterLink :to="{ name: 'scrap-management' }">Hurdalar</RouterLink> sayfasındaki
+            prosedürler öne çıkarılır.
+          </p>
+        </section>
+
+        <section class="contribution" aria-labelledby="contribution-title">
+          <h2 id="contribution-title">Güncel Katkılar</h2>
+          <ul>
+            <li v-for="entry in contributions" :key="entry.id">
+              <p class="contribution-title">{{ entry.title }}</p>
+              <p class="contribution-meta">
+                {{ entry.author }} • {{ entry.updatedAt }}
+              </p>
+              <RouterLink :to="{ name: entry.relatedRoute }" class="contribution-link">
+                {{ entry.relatedLabel }}
+              </RouterLink>
+            </li>
+          </ul>
+        </section>
+      </aside>
     </div>
   </section>
 </template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+
+type RouteName =
+  | 'inventory-tracking'
+  | 'license-tracking'
+  | 'printer-tracking'
+  | 'request-tracking'
+  | 'scrap-management'
+  | 'admin-panel'
+  | 'records';
+
+interface CategoryItem {
+  id: string;
+  title: string;
+  summary: string;
+  icon: string;
+  articles: string[];
+  routeName: RouteName;
+  linkLabel: string;
+  helperText: string;
+}
+
+interface ContributionItem {
+  id: string;
+  title: string;
+  author: string;
+  updatedAt: string;
+  relatedRoute: RouteName;
+  relatedLabel: string;
+}
+
+const categories: CategoryItem[] = [
+  {
+    id: 'inventory',
+    title: 'Envanter İşlemleri',
+    summary: 'Ürün girişleri, zimmet süreçleri ve teslim belgeleri.',
+    icon: '📦',
+    articles: [
+      'Envanter kartı oluşturma adımları',
+      'Teslim tutanağı şablonu',
+      'Yeni ürün seri numarası doğrulama'
+    ],
+    routeName: 'inventory-tracking',
+    linkLabel: 'Envanter modülünü aç',
+    helperText: 'Talep sonucu gelen ürünleri envantere aktarmayı unutmayın.'
+  },
+  {
+    id: 'licenses',
+    title: 'Lisans ve Hesap Yönetimi',
+    summary: 'Yazılım lisansları, kullanıcı yetkileri ve denetimler.',
+    icon: '🪪',
+    articles: [
+      'Yeni kullanıcı lisans talep formu',
+      'Lisans yenileme planı',
+      'Audit trail raporlama rehberi'
+    ],
+    routeName: 'license-tracking',
+    linkLabel: 'Lisans takibini görüntüle',
+    helperText: 'Talep edilen yetkilerin onayı ve kayıtları burada tutulur.'
+  },
+  {
+    id: 'support',
+    title: 'Destek ve Hızlı Çözümler',
+    summary: 'Arıza giderme, yazıcı bakımı ve sık sorulan sorular.',
+    icon: '🛠️',
+    articles: [
+      'Yazıcı kalibrasyonu nasıl yapılır?',
+      'Çağrı merkezi kulaklığı sorun giderme',
+      'Destek talebi SLA politikası'
+    ],
+    routeName: 'printer-tracking',
+    linkLabel: 'Yazıcı takibini aç',
+    helperText: 'Hurdaya ayrılan yazıcılar için ilgili prosedürlere bağlantı verilir.'
+  }
+];
+
+const contributions: ContributionItem[] = [
+  {
+    id: '1',
+    title: 'Hurda prosedürü güncellendi',
+    author: 'Selin Arı',
+    updatedAt: '10.03.2024',
+    relatedRoute: 'scrap-management',
+    relatedLabel: 'Hurda sürecine git'
+  },
+  {
+    id: '2',
+    title: 'LDAP bağlantı yönergesi',
+    author: 'Baran Yıldız',
+    updatedAt: '09.03.2024',
+    relatedRoute: 'admin-panel',
+    relatedLabel: 'Bağlantıları yapılandır'
+  },
+  {
+    id: '3',
+    title: 'Talep onay kontrol listesi',
+    author: 'IT Operasyonları',
+    updatedAt: '07.03.2024',
+    relatedRoute: 'request-tracking',
+    relatedLabel: 'Talep akışını gör'
+  }
+];
+</script>
 
 <style scoped>
 .page-section {
   display: grid;
   gap: 2.5rem;
   color: #0f172a;
+}
+
+.page-header {
+  display: grid;
+  gap: 1.75rem;
 }
 
 .page-header h1 {
@@ -43,44 +202,182 @@
 
 .page-intro {
   margin: 0;
-  max-width: 720px;
+  max-width: 760px;
   font-size: 1.05rem;
   color: #475569;
   line-height: 1.6;
 }
 
-.page-panels {
+.page-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.search-placeholder {
+  flex: 1 1 320px;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-radius: 18px;
+  border: 1px dashed rgba(37, 99, 235, 0.4);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.search-placeholder span {
+  font-size: 1.5rem;
+}
+
+.search-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.search-caption {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.page-tool-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.3rem;
+  border-radius: 999px;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.knowledge-grid {
   display: grid;
   gap: 1.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
 }
 
-.page-card {
-  padding: 2.25rem;
+.knowledge-card {
+  padding: 2rem;
   border-radius: 22px;
-  background: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  background: #ffffff;
   display: grid;
-  gap: 1.1rem;
+  gap: 1.5rem;
 }
 
-.page-card h2 {
-  margin: 0;
-  font-size: 1.4rem;
+.card-header {
+  display: flex;
+  gap: 1.25rem;
 }
 
-.page-card p {
+.card-header h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.35rem;
+}
+
+.card-header p {
   margin: 0;
   color: #475569;
-  line-height: 1.6;
+  line-height: 1.5;
 }
 
-.page-card ul {
+.card-icon {
+  font-size: 2rem;
+}
+
+.article-list {
   margin: 0;
   padding-left: 1.2rem;
   display: grid;
-  gap: 0.65rem;
+  gap: 0.6rem;
   color: #475569;
+}
+
+.card-footer {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.card-link {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.card-footer p {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.knowledge-side {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.callout,
+.contribution {
+  padding: 2rem;
+  border-radius: 22px;
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(14, 165, 233, 0.08));
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1rem;
+}
+
+.callout h2,
+.contribution h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.callout p,
+.contribution p {
+  margin: 0;
+  color: #1f2937;
+  line-height: 1.6;
+}
+
+.contribution ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.contribution-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.contribution-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.contribution-link {
+  color: #1d4ed8;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+@media (max-width: 1080px) {
+  .knowledge-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .page-tools {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }
 </style>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -1,38 +1,190 @@
 <template>
   <section class="page-section" aria-labelledby="profile-title">
     <header class="page-header">
-      <h1 id="profile-title">Profil</h1>
-      <p class="page-intro">
-        Kullanıcı bilgilerinizi, bildirim tercihlerinizi ve oturum geçmişinizi yönetin.
-      </p>
+      <div>
+        <h1 id="profile-title">Profil</h1>
+        <p class="page-intro">
+          Kullanıcı bilgilerinizi, ekip sorumluluklarınızı ve bildirim tercihlerinizi yönetin. Profil
+          bilgileri talep ve admin modülleri ile paylaşılarak yetkilerin doğru şekilde atanmasını sağlar.
+        </p>
+      </div>
+      <RouterLink :to="{ name: 'records' }" class="header-link">Hesap hareketlerini görüntüle</RouterLink>
     </header>
 
-    <div class="page-panels">
-      <article class="page-card">
-        <h2>Hesap Bilgileri</h2>
-        <p>
-          Bu alanda ad, soyad, e-posta ve iletişim bilgilerinizi güncelleyebilirsiniz. Şifre
-          değiştirme ve iki faktörlü doğrulama ayarları da burada yer alacaktır.
-        </p>
+    <div class="profile-grid">
+      <article class="profile-card" aria-labelledby="identity-title">
+        <header>
+          <h2 id="identity-title">Kullanıcı Bilgileri</h2>
+          <p>Zimmet, talep ve bildirimlerde kullanılacak temel bilgiler.</p>
+        </header>
+        <dl class="profile-list">
+          <div v-for="item in identity" :key="item.label">
+            <dt>{{ item.label }}</dt>
+            <dd>{{ item.value }}</dd>
+          </div>
+        </dl>
+        <footer>
+          <RouterLink :to="{ name: 'admin-panel' }" class="card-link">
+            Yetki matrisini kontrol et
+          </RouterLink>
+        </footer>
       </article>
 
-      <article class="page-card">
-        <h2>Aktivite Özeti</h2>
-        <ul>
-          <li>Son oturum açma tarihleri ve IP adresleri.</li>
-          <li>Yapılan kritik işlemler için bildirim geçmişi.</li>
-          <li>Bağlı cihazlar ve güvenlik kontrolleri.</li>
+      <article class="profile-card" aria-labelledby="responsibility-title">
+        <header>
+          <h2 id="responsibility-title">Ekip ve Sorumluluklar</h2>
+          <p>Operasyon süreçlerinde aktif rol aldığınız alanlar.</p>
+        </header>
+        <ul class="bullet-list">
+          <li v-for="item in responsibilities" :key="item">{{ item }}</li>
+        </ul>
+        <footer>
+          <RouterLink :to="{ name: 'request-tracking' }" class="card-link">
+            Talep görevlerini aç
+          </RouterLink>
+        </footer>
+      </article>
+
+      <article class="profile-card" aria-labelledby="preference-title">
+        <header>
+          <h2 id="preference-title">Bildirim Tercihleri</h2>
+          <p>Talep, hurda ve admin işlemleri için bildirim tercihleri.</p>
+        </header>
+        <ul class="preference-list">
+          <li v-for="item in preferences" :key="item.id">
+            <p class="preference-title">{{ item.title }}</p>
+            <p class="preference-note">{{ item.description }}</p>
+            <span class="preference-badge">{{ item.channel }}</span>
+          </li>
+        </ul>
+      </article>
+
+      <article class="profile-card" aria-labelledby="connections-title">
+        <header>
+          <h2 id="connections-title">Bağlı Modüller</h2>
+          <p>Kullanıcı bilgilerinizin aktarıldığı uygulama alanları.</p>
+        </header>
+        <ul class="connection-list">
+          <li v-for="connection in connections" :key="connection.id">
+            <div>
+              <p class="connection-title">{{ connection.title }}</p>
+              <p class="connection-note">{{ connection.note }}</p>
+            </div>
+            <RouterLink :to="{ name: connection.routeName }" class="connection-link">
+              {{ connection.linkLabel }}
+            </RouterLink>
+          </li>
         </ul>
       </article>
     </div>
   </section>
 </template>
 
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+
+type ConnectedRoute = 'request-tracking' | 'knowledge-base' | 'scrap-management' | 'admin-panel';
+
+interface IdentityItem {
+  label: string;
+  value: string;
+}
+
+interface PreferenceItem {
+  id: string;
+  title: string;
+  description: string;
+  channel: string;
+}
+
+interface ConnectionItem {
+  id: string;
+  title: string;
+  note: string;
+  routeName: ConnectedRoute;
+  linkLabel: string;
+}
+
+const identity: IdentityItem[] = [
+  { label: 'Kullanıcı Adı', value: 'syilmaz' },
+  { label: 'İsim', value: 'Selin Yılmaz' },
+  { label: 'Departman', value: 'BT Operasyonları' },
+  { label: 'E-posta', value: 'selin.yilmaz@example.com' },
+  { label: 'Telefon', value: '+90 555 123 45 67' }
+];
+
+const responsibilities: string[] = [
+  'Talep onaylarını yönetir ve SLA takibini yapar.',
+  'Hurda komitesi toplantılarında teknik rapor sunar.',
+  'Bilgi bankası içeriklerini günceller ve ekiplerle paylaşır.'
+];
+
+const preferences: PreferenceItem[] = [
+  {
+    id: '1',
+    title: 'Talep durumu güncellemesi',
+    description: 'Onaylanan veya reddedilen taleplerde bildirim al.',
+    channel: 'E-posta'
+  },
+  {
+    id: '2',
+    title: 'Hurda değerlendirme kararı',
+    description: 'Hurda listesine yeni bir kayıt eklendiğinde uyarı.',
+    channel: 'Slack'
+  },
+  {
+    id: '3',
+    title: 'Admin paneli değişiklikleri',
+    description: 'LDAP bağlantısı veya rol güncellemesi olduğunda bilgi.',
+    channel: 'Mobil'
+  }
+];
+
+const connections: ConnectionItem[] = [
+  {
+    id: '1',
+    title: 'Talep Yönetimi',
+    note: 'Taleplerde onaylayıcı ve takipçi olarak atanırsınız.',
+    routeName: 'request-tracking',
+    linkLabel: 'Talep akışına git'
+  },
+  {
+    id: '2',
+    title: 'Bilgi Bankası',
+    note: 'Dokümanlarda yazar ve editör olarak görünürsünüz.',
+    routeName: 'knowledge-base',
+    linkLabel: 'İçerikleri düzenle'
+  },
+  {
+    id: '3',
+    title: 'Hurdalar',
+    note: 'Hurda taleplerinde teknik raporlarınız paylaşılır.',
+    routeName: 'scrap-management',
+    linkLabel: 'Hurda sürecini aç'
+  },
+  {
+    id: '4',
+    title: 'Admin Paneli',
+    note: 'Rol ve yetki yönetimi için profil bilgileriniz kullanılır.',
+    routeName: 'admin-panel',
+    linkLabel: 'Yetkileri görüntüle'
+  }
+];
+</script>
+
 <style scoped>
 .page-section {
   display: grid;
   gap: 2.5rem;
   color: #0f172a;
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .page-header h1 {
@@ -42,44 +194,162 @@
 
 .page-intro {
   margin: 0;
-  max-width: 720px;
+  max-width: 760px;
   font-size: 1.05rem;
   color: #475569;
   line-height: 1.6;
 }
 
-.page-panels {
+.header-link {
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.profile-grid {
   display: grid;
   gap: 1.75rem;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
-.page-card {
-  padding: 2.25rem;
+.profile-card {
+  padding: 2rem;
   border-radius: 22px;
-  background: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  background: #ffffff;
   display: grid;
-  gap: 1.1rem;
+  gap: 1.5rem;
 }
 
-.page-card h2 {
-  margin: 0;
-  font-size: 1.4rem;
+.profile-card header h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.35rem;
 }
 
-.page-card p {
+.profile-card header p {
   margin: 0;
   color: #475569;
-  line-height: 1.6;
+  line-height: 1.5;
 }
 
-.page-card ul {
+.profile-list {
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.profile-list div {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.profile-list dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.profile-list dd {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.card-link {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.bullet-list {
   margin: 0;
   padding-left: 1.2rem;
   display: grid;
-  gap: 0.65rem;
+  gap: 0.6rem;
   color: #475569;
+}
+
+.preference-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.preference-list li {
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: rgba(241, 245, 249, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.preference-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.preference-note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.preference-badge {
+  justify-self: flex-start;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: #1d4ed8;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.connection-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.connection-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: rgba(241, 245, 249, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.connection-title {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+}
+
+.connection-note {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.connection-link {
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 720px) {
+  .connection-list li {
+    flex-direction: column;
+  }
 }
 </style>

--- a/frontend/src/views/RecordsView.vue
+++ b/frontend/src/views/RecordsView.vue
@@ -1,39 +1,185 @@
 <template>
   <section class="page-section" aria-labelledby="records-title">
     <header class="page-header">
-      <h1 id="records-title">Kayıtlar</h1>
-      <p class="page-intro">
-        Tüm modüllerde gerçekleşen işlemlerin denetim geçmişini görüntüleyin. Filtreler ve raporlar
-        sayesinde izlenebilirliği artırın.
-      </p>
+      <div>
+        <h1 id="records-title">Kayıtlar</h1>
+        <p class="page-intro">
+          Sistem genelinde yapılan ekleme, silme ve güncelleme işlemlerini tek ekrandan takip edin.
+          Modüller arası bağlantılar sayesinde hangi kaynağın hangi etkiyi oluşturduğunu görün.
+        </p>
+      </div>
+      <div class="filter-group" role="toolbar" aria-label="Kayıt filtreleri">
+        <button
+          v-for="filter in filters"
+          :key="filter.id"
+          type="button"
+          class="filter-button"
+        >
+          {{ filter.label }}
+        </button>
+      </div>
     </header>
 
-    <div class="page-panels">
-      <article class="page-card">
-        <h2>Raporlama</h2>
-        <ul>
-          <li>Tarih, kullanıcı, modül ve işlem tipine göre filtreleme.</li>
-          <li>Excel/PDF dışa aktarma ve planlanmış rapor gönderimi.</li>
-          <li>Riskli işlem uyarıları ve otomatik bildirimler.</li>
+    <div class="records-grid">
+      <article class="records-card" aria-labelledby="timeline-title">
+        <header>
+          <h2 id="timeline-title">Son İşlemler</h2>
+          <p>Modüllerde gerçekleşen önemli hareketler kronolojik olarak listelenir.</p>
+        </header>
+        <ul class="timeline">
+          <li v-for="entry in logs" :key="entry.id" class="timeline-entry">
+            <span class="timeline-dot" aria-hidden="true"></span>
+            <div class="timeline-content">
+              <p class="timeline-title">{{ entry.title }}</p>
+              <p class="timeline-meta">{{ entry.time }} • {{ entry.actor }}</p>
+              <p class="timeline-note">{{ entry.detail }}</p>
+              <RouterLink :to="{ name: entry.routeName }" class="timeline-link">
+                {{ entry.linkLabel }}
+              </RouterLink>
+            </div>
+          </li>
         </ul>
       </article>
 
-      <article class="page-card">
-        <h2>İlgili Modüller</h2>
-        <p>
-          Admin panelinden yetki değişiklikleri, talep modülündeki onaylar ve stok hareketleri
-          burada izlenebilir olacak.
-        </p>
+      <article class="records-card" aria-labelledby="insight-title">
+        <header>
+          <h2 id="insight-title">Öne Çıkan Kayıtlar</h2>
+          <p>Operasyon ekipleri için dikkat edilmesi gereken değişikliklerin özeti.</p>
+        </header>
+        <ul class="insight-list">
+          <li v-for="insight in insights" :key="insight.id">
+            <div>
+              <p class="insight-title">{{ insight.title }}</p>
+              <p class="insight-note">{{ insight.note }}</p>
+            </div>
+            <RouterLink :to="{ name: insight.routeName }" class="insight-link">
+              {{ insight.linkLabel }}
+            </RouterLink>
+          </li>
+        </ul>
       </article>
     </div>
+
+    <article class="workflow-card">
+      <h2>Denetim Akışı</h2>
+      <ol class="workflow-steps">
+        <li>
+          Talep, hurda veya admin modüllerinde yapılan değişiklikler otomatik olarak kayıt altına
+          alınır.
+        </li>
+        <li>
+          Kritik kayıtlar için bilgi bankasında ilgili dokümanlara bağlantı oluşturulur ve ekip
+          bilgilendirilir.
+        </li>
+        <li>
+          Denetim sonuçları finans ve insan kaynakları birimleriyle paylaşılmak üzere dışa aktarılır.
+        </li>
+      </ol>
+    </article>
   </section>
 </template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+
+type RouteName =
+  | 'request-tracking'
+  | 'scrap-management'
+  | 'admin-panel'
+  | 'inventory-tracking'
+  | 'knowledge-base';
+
+interface FilterItem {
+  id: string;
+  label: string;
+}
+
+interface LogEntry {
+  id: string;
+  title: string;
+  detail: string;
+  time: string;
+  actor: string;
+  routeName: RouteName;
+  linkLabel: string;
+}
+
+interface InsightItem {
+  id: string;
+  title: string;
+  note: string;
+  routeName: RouteName;
+  linkLabel: string;
+}
+
+const filters: FilterItem[] = [
+  { id: 'all', label: 'Tümü' },
+  { id: 'requests', label: 'Talepler' },
+  { id: 'scrap', label: 'Hurdalar' },
+  { id: 'admin', label: 'Admin İşlemleri' }
+];
+
+const logs: LogEntry[] = [
+  {
+    id: '1',
+    title: 'Talep RQ-1041 envantere taşındı',
+    detail: 'Dell Latitude 5440 kaydı otomatik olarak envanter kartına işlendi.',
+    time: '12.03.2024 11:24',
+    actor: 'Selin Yılmaz',
+    routeName: 'inventory-tracking',
+    linkLabel: 'Envanter hareketini incele'
+  },
+  {
+    id: '2',
+    title: 'Hurda isteği için onay verildi',
+    detail: 'Canon iR-ADV DX 4745i yazıcı hurda deposuna taşındı.',
+    time: '11.03.2024 15:42',
+    actor: 'Baran Yıldız',
+    routeName: 'scrap-management',
+    linkLabel: 'Hurda kaydını görüntüle'
+  },
+  {
+    id: '3',
+    title: 'LDAP bağlantı bilgisi güncellendi',
+    detail: 'Yeni servis hesabı eklendi ve parola sıfırlandı.',
+    time: '10.03.2024 09:15',
+    actor: 'IT Operasyonları',
+    routeName: 'admin-panel',
+    linkLabel: 'Bağlantı ayarını kontrol et'
+  }
+];
+
+const insights: InsightItem[] = [
+  {
+    id: '1',
+    title: 'Talep onay SLA sınırına yaklaşıyor',
+    note: 'Bekleyen 5 talep için stok teyidi yapılmalı.',
+    routeName: 'request-tracking',
+    linkLabel: 'Bekleyen talepleri aç'
+  },
+  {
+    id: '2',
+    title: 'Hurda prosedürü güncellemesi',
+    note: 'Yeni imha formu bilgi bankasına eklendi.',
+    routeName: 'knowledge-base',
+    linkLabel: 'Dokümana git'
+  }
+];
+</script>
 
 <style scoped>
 .page-section {
   display: grid;
   gap: 2.5rem;
   color: #0f172a;
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .page-header h1 {
@@ -43,44 +189,190 @@
 
 .page-intro {
   margin: 0;
-  max-width: 720px;
+  max-width: 760px;
   font-size: 1.05rem;
   color: #475569;
   line-height: 1.6;
 }
 
-.page-panels {
+.filter-group {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.filter-button {
+  padding: 0.6rem 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+  background: #ffffff;
+  color: #1f2937;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.records-grid {
   display: grid;
   gap: 1.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
 }
 
-.page-card {
-  padding: 2.25rem;
+.records-card {
+  padding: 2rem;
   border-radius: 22px;
-  background: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  background: #ffffff;
   display: grid;
-  gap: 1.1rem;
+  gap: 1.5rem;
 }
 
-.page-card h2 {
+.records-card header h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.35rem;
+}
+
+.records-card header p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.timeline {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline-entry {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  position: relative;
+}
+
+.timeline-entry::before {
+  content: '';
+  position: absolute;
+  left: 0.38rem;
+  top: 0.75rem;
+  bottom: -1rem;
+  width: 2px;
+  background: rgba(148, 163, 184, 0.4);
+}
+
+.timeline-entry:last-child::before {
+  display: none;
+}
+
+.timeline-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: #2563eb;
+  margin-top: 0.25rem;
+}
+
+.timeline-content {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.timeline-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.timeline-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.timeline-note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.timeline-link {
+  color: #2563eb;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.insight-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.insight-list li {
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: rgba(241, 245, 249, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.insight-title {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+}
+
+.insight-note {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.insight-link {
+  color: #2563eb;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.workflow-card {
+  padding: 2.5rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(14, 116, 144, 0.08));
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.workflow-card h2 {
   margin: 0;
   font-size: 1.4rem;
 }
 
-.page-card p {
-  margin: 0;
-  color: #475569;
-  line-height: 1.6;
-}
-
-.page-card ul {
+.workflow-steps {
   margin: 0;
   padding-left: 1.2rem;
   display: grid;
-  gap: 0.65rem;
-  color: #475569;
+  gap: 0.75rem;
+  color: #1f2937;
+  line-height: 1.6;
+}
+
+@media (max-width: 960px) {
+  .records-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline-entry::before {
+    bottom: -0.5rem;
+  }
+
+  .insight-list li {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 </style>

--- a/frontend/src/views/RequestTrackingView.vue
+++ b/frontend/src/views/RequestTrackingView.vue
@@ -1,39 +1,260 @@
 <template>
   <section class="page-section" aria-labelledby="request-title">
     <header class="page-header">
-      <h1 id="request-title">Talep Takip</h1>
-      <p class="page-intro">
-        Kullanıcılardan gelen envanter, lisans veya destek taleplerini yönetin. Onay akışları ve SLA
-        süreleri bu modülde takip edilecektir.
-      </p>
+      <div>
+        <h1 id="request-title">Talep Takip</h1>
+        <p class="page-intro">
+          Envanter, lisans ve destek ihtiyaçları için açılan talepleri uçtan uca yönetin. Durumlara
+          göre iş akışlarını takip ederek onaylanan ürünleri envantere aktarın, iptal edilenleri ise
+          kayıt altına alarak süreci şeffaflaştırın.
+        </p>
+      </div>
+
+      <div class="status-summary" role="list">
+        <article
+          v-for="summary in statusSummary"
+          :key="summary.id"
+          class="summary-card"
+          role="listitem"
+        >
+          <span class="summary-label">{{ summary.title }}</span>
+          <p class="summary-count">{{ summary.count }}</p>
+          <span class="summary-caption">{{ totalRequests }} toplam talebin içinde</span>
+        </article>
+      </div>
     </header>
 
-    <div class="page-panels">
-      <article class="page-card">
-        <h2>Bekleyen Görevler</h2>
-        <ul>
-          <li>Onay bekleyen talepler için bildirim sistemi.</li>
-          <li>Talepleri tipine göre sınıflandırma (envanter, lisans, destek).</li>
-          <li>İş akışı adımlarını özelleştirilebilir hale getirme.</li>
-        </ul>
-      </article>
+    <div class="status-board" role="list">
+      <article
+        v-for="column in requestColumns"
+        :key="column.id"
+        class="status-column"
+        role="listitem"
+        :style="{ '--column-accent': column.accent }"
+      >
+        <header class="column-header">
+          <div>
+            <h2>{{ column.title }}</h2>
+            <p>{{ column.description }}</p>
+          </div>
+          <span class="column-badge">{{ column.items.length }}</span>
+        </header>
 
-      <article class="page-card">
-        <h2>İş Birlikleri</h2>
-        <p>
-          Stok ve envanter modülleri ile doğrudan bağlantı kurarak onaylanan taleplerin otomatik
-          olarak stok düşümü yapmasını sağlayın.
-        </p>
+        <ul class="request-list">
+          <li v-for="item in column.items" :key="item.id" class="request-item">
+            <div class="request-meta">
+              <p class="request-title">{{ item.title }}</p>
+              <p class="request-details">
+                <span>{{ item.requester }}</span>
+                <span aria-hidden="true">•</span>
+                <span>{{ item.product }}</span>
+              </p>
+              <p class="request-note">{{ item.statusNote }}</p>
+            </div>
+            <div class="request-actions">
+              <span class="request-tag">{{ item.updatedAt }}</span>
+              <RouterLink :to="{ name: item.targetRoute }" class="request-link">
+                {{ item.targetLabel }}
+              </RouterLink>
+            </div>
+          </li>
+        </ul>
+
+        <footer class="column-footer">
+          <RouterLink :to="{ name: column.footerRoute }" class="footer-link">
+            {{ column.footerLabel }}
+          </RouterLink>
+          <p class="footer-note">{{ column.footerNote }}</p>
+        </footer>
       </article>
     </div>
+
+    <article class="workflow-card">
+      <h2>Operasyon Akışı</h2>
+      <ol class="workflow-steps">
+        <li>
+          Talep açılır ve durum <strong>Bekleyen</strong> olarak kaydedilir. İlgili stoklar için
+          <RouterLink :to="{ name: 'stock-tracking' }">Stok Takip</RouterLink> modülünden rezervasyon
+          yapılır.
+        </li>
+        <li>
+          Ürün teslim edildiğinde statü <strong>Karşılandı</strong> olur ve
+          <RouterLink :to="{ name: 'inventory-tracking' }">Envanter Takip</RouterLink> modülüne
+          otomatik giriş yapılır.
+        </li>
+        <li>
+          Reddedilen veya iptal edilen talepler <strong>İptal</strong> kolonuna taşınır ve
+          <RouterLink :to="{ name: 'records' }">Kayıtlar</RouterLink> bölümünde loglanır.
+        </li>
+      </ol>
+
+      <div class="workflow-actions">
+        <RouterLink :to="{ name: 'knowledge-base' }" class="workflow-link">
+          İlgili dokümanları aç
+        </RouterLink>
+        <RouterLink :to="{ name: 'admin-panel' }" class="workflow-link">
+          Onay kurallarını düzenle
+        </RouterLink>
+      </div>
+    </article>
   </section>
 </template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { RouterLink } from 'vue-router';
+
+type RequestStatus = 'pending' | 'delivered' | 'cancelled';
+
+interface RequestItem {
+  id: string;
+  title: string;
+  requester: string;
+  product: string;
+  status: RequestStatus;
+  updatedAt: string;
+  statusNote: string;
+  targetRoute: string;
+  targetLabel: string;
+}
+
+interface BaseColumn {
+  id: RequestStatus;
+  title: string;
+  description: string;
+  accent: string;
+  footerLabel: string;
+  footerRoute: string;
+  footerNote: string;
+}
+
+const requests: RequestItem[] = [
+  {
+    id: 'RQ-1045',
+    title: 'Yeni dizüstü bilgisayar talebi',
+    requester: 'Ayşe Yılmaz',
+    product: 'Dell Latitude 5440',
+    status: 'pending',
+    updatedAt: '11.03.2024',
+    statusNote: 'Tedarik biriminden stok teyidi bekleniyor.',
+    targetRoute: 'stock-tracking',
+    targetLabel: 'Stok kontrolüne git'
+  },
+  {
+    id: 'RQ-1046',
+    title: 'Adobe lisans yenilemesi',
+    requester: 'Kerem Durmaz',
+    product: 'Adobe Creative Cloud',
+    status: 'pending',
+    updatedAt: '12.03.2024',
+    statusNote: 'Finans onayı son aşamada.',
+    targetRoute: 'license-tracking',
+    targetLabel: 'Lisans kaydını aç'
+  },
+  {
+    id: 'RQ-1041',
+    title: 'Çağrı merkezi kulaklığı değişimi',
+    requester: 'Elif Ak',
+    product: 'Jabra Evolve 65',
+    status: 'delivered',
+    updatedAt: '08.03.2024',
+    statusNote: 'Teslim edildi, envanterde kayıt oluşturuldu.',
+    targetRoute: 'inventory-tracking',
+    targetLabel: 'Envanter kartını gör'
+  },
+  {
+    id: 'RQ-1033',
+    title: 'Yazıcı toner siparişi',
+    requester: 'Operasyon Ekibi',
+    product: 'HP 410X Toner Seti',
+    status: 'delivered',
+    updatedAt: '06.03.2024',
+    statusNote: 'Teslim edildi, yazıcı stokları güncellendi.',
+    targetRoute: 'printer-tracking',
+    targetLabel: 'Yazıcı kaydını aç'
+  },
+  {
+    id: 'RQ-1027',
+    title: 'ERP erişim talebi',
+    requester: 'Mert Çelik',
+    product: 'SAP Kullanıcı Yetkisi',
+    status: 'cancelled',
+    updatedAt: '04.03.2024',
+    statusNote: 'Talep sahibi tarafından iptal edildi.',
+    targetRoute: 'records',
+    targetLabel: 'Log kaydını görüntüle'
+  },
+  {
+    id: 'RQ-1019',
+    title: 'Arızalı yazıcı hurdaya çıkarma',
+    requester: 'Destek Ekibi',
+    product: 'Canon iR-ADV DX 4745i',
+    status: 'cancelled',
+    updatedAt: '01.03.2024',
+    statusNote: 'Hurda komitesi kararı bekleniyor, kayıtlar güncellendi.',
+    targetRoute: 'scrap-management',
+    targetLabel: 'Hurda listesini kontrol et'
+  }
+];
+
+const baseColumns: BaseColumn[] = [
+  {
+    id: 'pending',
+    title: 'Bekleyen Talepler',
+    description: 'Onay ve stok kontrolü sürecindeki talepler.',
+    accent: '#f59e0b',
+    footerLabel: 'Stok ve finans kontrollerine git',
+    footerRoute: 'stock-tracking',
+    footerNote: 'Taleplerin karşılanması için stok rezervasyonlarını yönetin.'
+  },
+  {
+    id: 'delivered',
+    title: 'Karşılanan Talepler',
+    description: 'Teslimi yapılan ve envantere işlenen talepler.',
+    accent: '#22c55e',
+    footerLabel: 'Envanter kayıtlarını görüntüle',
+    footerRoute: 'inventory-tracking',
+    footerNote: 'Teslim edilen ürünlerin envanter kartlarını inceleyin.'
+  },
+  {
+    id: 'cancelled',
+    title: 'İptal / Reddedilen Talepler',
+    description: 'İptal edilen veya hurda değerlendirmesi bekleyen talepler.',
+    accent: '#ef4444',
+    footerLabel: 'Hurda listesini kontrol et',
+    footerRoute: 'scrap-management',
+    footerNote: 'İptal gerekçeleri için kayıtlar modülünü incelemeyi unutmayın.'
+  }
+];
+
+const requestColumns = computed(() =>
+  baseColumns.map((column) => ({
+    ...column,
+    items: requests.filter((request) => request.status === column.id)
+  }))
+);
+
+const statusSummary = computed(() =>
+  requestColumns.value.map((column) => ({
+    id: column.id,
+    title: column.title,
+    count: column.items.length
+  }))
+);
+
+const totalRequests = computed(() => requests.length);
+</script>
 
 <style scoped>
 .page-section {
   display: grid;
   gap: 2.5rem;
   color: #0f172a;
+}
+
+.page-header {
+  display: grid;
+  gap: 1.75rem;
 }
 
 .page-header h1 {
@@ -43,44 +264,236 @@
 
 .page-intro {
   margin: 0;
-  max-width: 720px;
+  max-width: 760px;
   font-size: 1.05rem;
   color: #475569;
   line-height: 1.6;
 }
 
-.page-panels {
+.status-summary {
   display: grid;
-  gap: 1.75rem;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.summary-card {
+  padding: 1.5rem;
+  border-radius: 18px;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.summary-label {
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.summary-count {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.summary-caption {
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.status-board {
+  display: grid;
+  gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
-.page-card {
-  padding: 2.25rem;
+.status-column {
+  position: relative;
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem;
   border-radius: 22px;
   background: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
-  display: grid;
-  gap: 1.1rem;
+  overflow: hidden;
 }
 
-.page-card h2 {
-  margin: 0;
-  font-size: 1.4rem;
+.status-column::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 22px;
+  border: 2px solid var(--column-accent);
+  opacity: 0.1;
+  pointer-events: none;
 }
 
-.page-card p {
+.column-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.column-header h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.35rem;
+}
+
+.column-header p {
   margin: 0;
   color: #475569;
-  line-height: 1.6;
+  line-height: 1.5;
 }
 
-.page-card ul {
+.column-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--column-accent);
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.request-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.request-item {
+  padding: 1.25rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(241, 245, 249, 0.45);
+}
+
+.request-meta {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.request-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.request-details {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.request-note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.request-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.request-tag {
+  font-size: 0.85rem;
+  color: #64748b;
+  background: rgba(148, 163, 184, 0.2);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+}
+
+.request-link {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.column-footer {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.footer-link {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.footer-note {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.workflow-card {
+  padding: 2.5rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(37, 99, 235, 0.08));
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.workflow-card h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.workflow-steps {
   margin: 0;
   padding-left: 1.2rem;
   display: grid;
-  gap: 0.65rem;
-  color: #475569;
+  gap: 0.75rem;
+  color: #1e293b;
+  line-height: 1.6;
+}
+
+.workflow-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.workflow-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.workflow-link:hover {
+  background: #1e3a8a;
+}
+
+@media (max-width: 960px) {
+  .request-actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .workflow-card {
+    padding: 2rem;
+  }
 }
 </style>

--- a/frontend/src/views/ScrapManagementView.vue
+++ b/frontend/src/views/ScrapManagementView.vue
@@ -1,39 +1,186 @@
 <template>
   <section class="page-section" aria-labelledby="scrap-title">
     <header class="page-header">
-      <h1 id="scrap-title">Hurdalar</h1>
-      <p class="page-intro">
-        Hurdaya ayrılması planlanan veya süreci devam eden ekipmanları listeleyin. Onay süreçleri ve
-        elden çıkarma belgeleri bu bölümde tutulacaktır.
-      </p>
+      <div>
+        <h1 id="scrap-title">Hurdalar</h1>
+        <p class="page-intro">
+          Yazıcılar ve envanterdeki varlıkların hurdaya ayrılma sürecini planlayın. Değerleme,
+          onaylama ve imha adımlarını kayıt altında tutarak envanter döngüsünü tamamlayın.
+        </p>
+      </div>
+
+      <RouterLink :to="{ name: 'records' }" class="page-link">
+        Hurda loglarını aç
+      </RouterLink>
     </header>
 
-    <div class="page-panels">
-      <article class="page-card">
-        <h2>Takip Başlıkları</h2>
-        <ul>
-          <li>Hurda nedenleri ve finansal etkilerinin kaydı.</li>
-          <li>Yetkili onay zincirlerinin takibi.</li>
-          <li>Fotoğraf ve belge ekleri için arşiv alanı.</li>
-        </ul>
+    <div class="scrap-grid">
+      <article class="scrap-card" aria-labelledby="evaluation-title">
+        <header>
+          <h2 id="evaluation-title">Değerlendirme Aşamasındakiler</h2>
+          <p>
+            Hurdaya ayrılmak üzere bekleyen ekipmanlar. Talep modülü üzerinden gelen tüm kayıtlar
+            teknik ekip tarafından incelenir.
+          </p>
+        </header>
+        <table class="scrap-table">
+          <thead>
+            <tr>
+              <th scope="col">Varlık</th>
+              <th scope="col">Durum</th>
+              <th scope="col">Talep</th>
+              <th scope="col">Son Güncelleme</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in evaluationItems" :key="item.id">
+              <td>
+                <span class="asset-name">{{ item.asset }}</span>
+                <span class="asset-tag">{{ item.tag }}</span>
+              </td>
+              <td>{{ item.status }}</td>
+              <td>
+                <RouterLink :to="{ name: 'request-tracking' }" class="table-link">
+                  {{ item.requestId }}
+                </RouterLink>
+              </td>
+              <td>{{ item.updatedAt }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <footer>
+          <RouterLink :to="{ name: 'request-tracking' }" class="footer-link">
+            Talep akışına geri dön
+          </RouterLink>
+        </footer>
       </article>
 
-      <article class="page-card">
-        <h2>Entegrasyon Senaryoları</h2>
-        <p>
-          Envanter kartlarını hurda durumuna geçirerek stoktan düşmesini sağlayın. Kayıtlar modülü ile
-          birlikte tüm geçmiş işlemleri raporlayın.
-        </p>
+      <article class="scrap-card" aria-labelledby="completed-title">
+        <header>
+          <h2 id="completed-title">Hurdaya Ayrılmış Envanter</h2>
+          <p>
+            Onaylanmış ve imha planı oluşturulmuş varlıklar. Envanter takibi ile eş zamanlı olarak
+            stok düşümü yapılır.
+          </p>
+        </header>
+        <ul class="scrap-list">
+          <li v-for="record in completedItems" :key="record.id" class="scrap-list-item">
+            <div>
+              <p class="list-title">{{ record.asset }}</p>
+              <p class="list-meta">{{ record.serial }} • {{ record.location }}</p>
+              <p class="list-note">{{ record.note }}</p>
+            </div>
+            <RouterLink :to="{ name: record.relatedRoute }" class="list-link">
+              {{ record.relatedLabel }}
+            </RouterLink>
+          </li>
+        </ul>
+        <footer>
+          <RouterLink :to="{ name: 'inventory-tracking' }" class="footer-link">
+            Envanterdeki karşılıkları kontrol et
+          </RouterLink>
+        </footer>
       </article>
     </div>
+
+    <article class="workflow-card">
+      <h2>Hurda Süreci Adımları</h2>
+      <ol class="workflow-steps">
+        <li>
+          Talep modülünden gelen hurda isteği teknik değerlendirmeden geçer ve değer kaybı raporu
+          hazırlanır.
+        </li>
+        <li>
+          Onaylanan cihazlar için <RouterLink :to="{ name: 'admin-panel' }">Admin Paneli</RouterLink>
+          üzerinden yetkili imzalar toplanır.
+        </li>
+        <li>
+          İmha edilen ekipmanlar <RouterLink :to="{ name: 'records' }">Kayıtlar</RouterLink>
+          modülüne aktarılır ve finans birimine raporlanır.
+        </li>
+      </ol>
+    </article>
   </section>
 </template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+
+type RouteName = 'printer-tracking' | 'inventory-tracking' | 'scrap-management' | 'records';
+
+interface EvaluationItem {
+  id: string;
+  asset: string;
+  tag: string;
+  status: string;
+  requestId: string;
+  updatedAt: string;
+}
+
+interface CompletedItem {
+  id: string;
+  asset: string;
+  serial: string;
+  location: string;
+  note: string;
+  relatedRoute: RouteName;
+  relatedLabel: string;
+}
+
+const evaluationItems: EvaluationItem[] = [
+  {
+    id: '1',
+    asset: 'Canon iR-ADV DX 4745i Yazıcı',
+    tag: 'PRN-00213',
+    status: 'Teknik inceleme bekleniyor',
+    requestId: 'RQ-1019',
+    updatedAt: '11.03.2024'
+  },
+  {
+    id: '2',
+    asset: 'Dell OptiPlex 7080 SFF',
+    tag: 'INV-00874',
+    status: 'Finans onayı aşamasında',
+    requestId: 'RQ-1008',
+    updatedAt: '10.03.2024'
+  }
+];
+
+const completedItems: CompletedItem[] = [
+  {
+    id: '1',
+    asset: 'HP LaserJet Pro M404dn',
+    serial: 'CNBXJ1F035',
+    location: 'Merkez depo',
+    note: 'Yedek parça olarak ayrıldı, toner deposu aktarıldı.',
+    relatedRoute: 'printer-tracking',
+    relatedLabel: 'Yazıcı kaydını incele'
+  },
+  {
+    id: '2',
+    asset: 'Lenovo ThinkPad T490',
+    serial: 'PF1ABCD23',
+    location: 'Hurda deposu',
+    note: 'Parola sıfırlama başarısız, disk imhası tamamlandı.',
+    relatedRoute: 'inventory-tracking',
+    relatedLabel: 'Envanter geçmişini aç'
+  }
+];
+</script>
 
 <style scoped>
 .page-section {
   display: grid;
   gap: 2.5rem;
   color: #0f172a;
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .page-header h1 {
@@ -49,38 +196,157 @@
   line-height: 1.6;
 }
 
-.page-panels {
+.page-link {
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  background: #1f2937;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.scrap-grid {
   display: grid;
   gap: 1.75rem;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
-.page-card {
-  padding: 2.25rem;
+.scrap-card {
+  padding: 2rem;
   border-radius: 22px;
-  background: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+  background: #ffffff;
   display: grid;
-  gap: 1.1rem;
+  gap: 1.5rem;
 }
 
-.page-card h2 {
+.scrap-card header h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.4rem;
+}
+
+.scrap-card header p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.scrap-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.scrap-table th,
+.scrap-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.scrap-table th {
+  color: #475569;
+  font-weight: 600;
+  background: rgba(226, 232, 240, 0.35);
+}
+
+.asset-name {
+  display: block;
+  font-weight: 600;
+}
+
+.asset-tag {
+  display: block;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.table-link {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.scrap-card footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.footer-link {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.scrap-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.scrap-list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: rgba(241, 245, 249, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.list-title {
+  margin: 0 0 0.4rem;
+  font-weight: 600;
+}
+
+.list-meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.list-note {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.list-link {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.workflow-card {
+  padding: 2.5rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.08), rgba(37, 99, 235, 0.08));
+  border: 1px solid rgba(16, 185, 129, 0.15);
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.workflow-card h2 {
   margin: 0;
   font-size: 1.4rem;
 }
 
-.page-card p {
-  margin: 0;
-  color: #475569;
-  line-height: 1.6;
-}
-
-.page-card ul {
+.workflow-steps {
   margin: 0;
   padding-left: 1.2rem;
   display: grid;
-  gap: 0.65rem;
-  color: #475569;
+  gap: 0.75rem;
+  color: #1f2937;
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  .scrap-list-item {
+    flex-direction: column;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- redesign the Talep Takip view with status-driven boards, workflow guidance, and navigation into related modules
- expand the Bilgi Bankası, Hurdalar, Profil, and Admin Paneli screens with structured data, contextual actions, and cross-page links
- refresh the Kayıtlar denetim sayfası to include timeline highlights, quick filters, and module shortcuts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f0ed5c48d4832bb1c0d5d6360459f9