### PR TITLE
Add Talep Aç modal to request tracking page

### DIFF
--- a/frontend/src/views/AdminPanelView.vue
+++ b/frontend/src/views/AdminPanelView.vue
@@ -1,247 +1,299 @@
 <template>
-  <section class="admin-page" aria-labelledby="admin-panel-title">
-    <div class="panel-card">
-      <header class="panel-header">
-        <div class="panel-heading">
-          <span class="panel-badge">Yönetim Modülü</span>
-          <h1 id="admin-panel-title">Admin Paneli</h1>
-          <p class="panel-intro">
-            Rolleri, ürün modüllerini ve entegrasyon bağlantılarını tek noktadan yönetin. Tüm
-            güncellemeler ilgili modüllere otomatik olarak aktarılır.
+  <section class="admin-layout" aria-labelledby="admin-panel-heading">
+    <aside class="side-nav" aria-label="Uygulama menüsü">
+      <div v-for="group in navGroups" :key="group.title" class="nav-group">
+        <p class="nav-title">{{ group.title }}</p>
+        <RouterLink
+          v-for="item in group.items"
+          :key="item.route"
+          :to="{ name: item.route }"
+          class="nav-link"
+          :class="{ active: item.route === 'admin-panel' }"
+        >
+          <span class="nav-icon" aria-hidden="true">{{ item.icon }}</span>
+          <span>{{ item.label }}</span>
+        </RouterLink>
+      </div>
+    </aside>
+
+    <main class="panel-area">
+      <header class="page-hero">
+        <div class="hero-copy">
+          <span class="hero-badge">Ayarlar</span>
+          <h1 id="admin-panel-heading">Admin Paneli</h1>
+          <p>
+            Kullanıcı yetkilerini, ürün kataloglarını ve LDAP bağlantılarını tek merkezden yöneterek
+            tüm modüllere eş zamanlı güncellemeler aktarın.
           </p>
         </div>
-        <div class="panel-actions">
-          <RouterLink :to="primaryActionRoute" class="primary-action">
-            {{ primaryActionLabel }}
-          </RouterLink>
-          <label class="search-field" :class="{ disabled: isSearchDisabled }">
-            <span class="search-icon" aria-hidden="true">🔍</span>
-            <input
-              v-model="searchQuery"
-              type="search"
-              :disabled="isSearchDisabled"
-              :aria-disabled="isSearchDisabled"
-              placeholder="Kullanıcı veya ekip ara"
-              aria-label="Kullanıcı arama"
-              :aria-controls="isSearchDisabled ? undefined : 'users-table'"
-            />
-          </label>
+        <div class="hero-stat">
+          <p class="stat-label">Aktif Kullanıcı</p>
+          <p class="stat-value">{{ activeUserCount }}</p>
+          <RouterLink :to="{ name: 'profile' }" class="stat-link">Profil detayına git</RouterLink>
         </div>
       </header>
 
-      <nav class="panel-tabs" aria-label="Panel içerikleri">
-        <button
-          v-for="tab in tabItems"
-          :key="tab.id"
-          type="button"
-          class="panel-tab"
-          :class="{ active: activeTab === tab.id }"
-          @click="activeTab = tab.id"
-        >
-          <span class="tab-icon" aria-hidden="true">{{ tab.icon }}</span>
-          <span class="tab-text">
-            <span class="tab-label">{{ tab.label }}</span>
-            <span class="tab-caption">{{ tab.caption }}</span>
-          </span>
-        </button>
-      </nav>
+      <section class="panel-card" :aria-labelledby="`tab-${activeTab}`">
+        <header class="panel-header">
+          <nav class="tab-list" aria-label="Panel sekmeleri">
+            <button
+              v-for="tab in tabItems"
+              :key="tab.id"
+              type="button"
+              class="tab-button"
+              :class="{ active: activeTab === tab.id }"
+              @click="activeTab = tab.id"
+            >
+              <span>{{ tab.label }}</span>
+              <span class="tab-caption">{{ tab.caption }}</span>
+            </button>
+          </nav>
+          <div class="panel-toolbar">
+            <label class="search-field" :class="{ disabled: isSearchDisabled }">
+              <span class="search-icon" aria-hidden="true">🔍</span>
+              <input
+                v-model="searchQuery"
+                type="search"
+                :disabled="isSearchDisabled"
+                :aria-disabled="isSearchDisabled"
+                placeholder="Ara..."
+                aria-label="Kullanıcı ara"
+              />
+            </label>
+            <button type="button" class="toolbar-button" @click="handleToolbarAction">
+              {{ toolbarButtonLabel }}
+            </button>
+          </div>
+        </header>
 
-      <div class="panel-body">
-        <div v-if="activeTab === 'users'" class="tab-panel users-panel">
-          <table id="users-table" class="admin-table">
-            <thead>
-              <tr>
-                <th scope="col">Ad</th>
-                <th scope="col">Departman</th>
-                <th scope="col">E-posta</th>
-                <th scope="col">Son Giriş</th>
-                <th scope="col">Modül</th>
-              </tr>
-            </thead>
-            <tbody v-if="filteredUsers.length">
-              <tr v-for="user in filteredUsers" :key="user.id">
-                <td>
-                  <span class="user-name">{{ user.name }}</span>
-                </td>
-                <td>{{ user.department }}</td>
-                <td>{{ user.email }}</td>
-                <td>{{ user.lastLogin }}</td>
-                <td>
-                  <RouterLink :to="{ name: user.routeName }" class="table-link">
-                    {{ user.module }}
-                  </RouterLink>
-                </td>
-              </tr>
-            </tbody>
-            <tbody v-else>
-              <tr>
-                <td colspan="5" class="empty-row">Henüz kullanıcı kaydı bulunmuyor.</td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="panel-body">
+          <div v-if="activeTab === 'users'" class="users-tab" role="region" aria-live="polite">
+            <header class="tab-copy">
+              <h2 id="tab-users">Kullanıcı Yönetimi</h2>
+              <p>Rolleri, ekip atamalarını ve modül izinlerini güncelleyin.</p>
+            </header>
+            <div class="table-wrapper">
+              <table class="admin-table">
+                <thead>
+                  <tr>
+                    <th scope="col">No</th>
+                    <th scope="col">Kullanıcı Adı</th>
+                    <th scope="col">Ad Soyad</th>
+                    <th scope="col">E-posta</th>
+                    <th scope="col">Rol</th>
+                    <th scope="col" class="actions">İşlemler</th>
+                  </tr>
+                </thead>
+                <tbody v-if="filteredUsers.length">
+                  <tr v-for="user in filteredUsers" :key="user.id">
+                    <td data-title="No">{{ user.order }}</td>
+                    <td data-title="Kullanıcı Adı">{{ user.username }}</td>
+                    <td data-title="Ad Soyad">{{ user.fullName }}</td>
+                    <td data-title="E-posta">{{ user.email }}</td>
+                    <td data-title="Rol">{{ user.role }}</td>
+                    <td data-title="İşlemler" class="actions">
+                      <button type="button" class="link-button" @click="goToProfile(user.routeName)">
+                        Düzenle
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+                <tbody v-else>
+                  <tr>
+                    <td colspan="6" class="empty-state">Kayıt bulunamadı.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div v-else-if="activeTab === 'product'" class="product-tab" role="region">
+            <header class="tab-copy">
+              <h2 id="tab-product">Ürün / Envanter Ekle</h2>
+              <p>Yeni lisans ya da donanım girişlerini ilgili alanlarla kaydedin.</p>
+            </header>
+            <form class="product-form" @submit.prevent="handleToolbarAction">
+              <div v-for="field in productFields" :key="field.id" class="form-field">
+                <label :for="field.id">{{ field.label }}</label>
+                <input :id="field.id" :placeholder="field.placeholder" type="text" />
+              </div>
+            </form>
+          </div>
+
+          <div v-else class="connections-tab" role="region">
+            <header class="tab-copy">
+              <h2 id="tab-connections">LDAP Bağlantıları</h2>
+              <p>Sunucu bağlantılarını gözlemleyin ve yapılandırmaları yönetin.</p>
+            </header>
+            <div class="table-wrapper">
+              <table class="admin-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Ad</th>
+                    <th scope="col">Sunucu</th>
+                    <th scope="col">Port</th>
+                    <th scope="col">Base DN</th>
+                    <th scope="col">Kullanıcı</th>
+                    <th scope="col" class="actions">İşlemler</th>
+                  </tr>
+                </thead>
+                <tbody v-if="integrationRows.length">
+                  <tr v-for="integration in integrationRows" :key="integration.id">
+                    <td data-title="Ad">{{ integration.name }}</td>
+                    <td data-title="Sunucu">{{ integration.server }}</td>
+                    <td data-title="Port">{{ integration.port }}</td>
+                    <td data-title="Base DN">{{ integration.baseDn }}</td>
+                    <td data-title="Kullanıcı">{{ integration.username }}</td>
+                    <td data-title="İşlemler" class="actions">
+                      <button type="button" class="link-button" @click="configureIntegration(integration)">
+                        Ayarla
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+                <tbody v-else>
+                  <tr>
+                    <td colspan="6" class="empty-state">Kayıt yok.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
-
-        <div v-else-if="activeTab === 'modules'" class="tab-panel modules-panel">
-          <template v-if="moduleCards.length">
-            <ul class="module-grid" role="list">
-              <li v-for="module in moduleCards" :key="module.id" class="module-card" role="listitem">
-                <div class="module-icon" aria-hidden="true">{{ module.icon }}</div>
-                <div class="module-text">
-                  <p class="module-label">{{ module.title }}</p>
-                  <p class="module-meta">{{ module.module }} • {{ module.count }} kayıt</p>
-                  <p class="module-note">{{ module.description }}</p>
-                </div>
-                <RouterLink :to="{ name: module.routeName }" class="module-link">
-                  {{ module.linkLabel }}
-                </RouterLink>
-              </li>
-            </ul>
-          </template>
-          <p v-else class="empty-state">Henüz modül bilgisi eklenmemiş.</p>
-        </div>
-
-        <div v-else class="tab-panel integrations-panel">
-          <template v-if="integrationCards.length">
-            <ul class="integration-grid" role="list">
-              <li
-                v-for="integration in integrationCards"
-                :key="integration.id"
-                class="integration-card"
-                role="listitem"
-              >
-                <div class="integration-icon" aria-hidden="true">{{ integration.icon }}</div>
-                <div class="integration-text">
-                  <p class="integration-label">{{ integration.title }}</p>
-                  <p class="integration-status">{{ integration.status }}</p>
-                  <p class="integration-note">{{ integration.note }}</p>
-                </div>
-                <RouterLink :to="{ name: integration.routeName }" class="integration-link">
-                  {{ integration.linkLabel }}
-                </RouterLink>
-              </li>
-            </ul>
-          </template>
-          <p v-else class="empty-state">Henüz entegrasyon bağlantısı eklenmemiş.</p>
-        </div>
-      </div>
-    </div>
-
-    <article class="workflow-card">
-      <header>
-        <h2>Yönetim Döngüsü</h2>
-        <p>
-          Modüller arası entegrasyonlar otomatik aktarılır. Güncellemeler anlık olarak tüm ekiplere
-          yansır.
-        </p>
-      </header>
-      <ol class="workflow-steps">
-        <li>
-          Rol atamaları tamamlandığında detaylar
-          <RouterLink :to="{ name: 'profile' }">Profil</RouterLink> ekranında görüntülenir ve
-          ilgili bildirimler gönderilir.
-        </li>
-        <li>
-          Ürün kataloglarında yapılan değişiklikler
-          <RouterLink :to="{ name: 'request-tracking' }">Talep Takip</RouterLink> ve
-          <RouterLink :to="{ name: 'inventory-tracking' }">Envanter Takip</RouterLink>
-          formlarına otomatik olarak yansır.
-        </li>
-        <li>
-          LDAP ve SSO entegrasyon güncellemeleri anlık olarak
-          <RouterLink :to="{ name: 'records' }">Kayıtlar</RouterLink> modülüne loglanır ve
-          <RouterLink :to="{ name: 'knowledge-base' }">Bilgi Bankası</RouterLink> rehberlerinde
-          yayınlanır.
-        </li>
-      </ol>
-    </article>
+      </section>
+    </main>
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { RouterLink, type RouteLocationRaw } from 'vue-router';
+import { RouterLink, useRouter } from 'vue-router';
 
 type RouteName =
   | 'home'
   | 'inventory-tracking'
-  | 'request-tracking'
-  | 'printer-tracking'
   | 'license-tracking'
-  | 'admin-panel'
-  | 'profile'
+  | 'printer-tracking'
+  | 'stock-tracking'
+  | 'request-tracking'
   | 'knowledge-base'
-  | 'records'
-  | 'scrap-management';
+  | 'scrap-management'
+  | 'profile'
+  | 'admin-panel'
+  | 'records';
 
-type TabId = 'users' | 'modules' | 'integrations';
+type TabId = 'users' | 'product' | 'connections';
 
 interface TabItem {
   id: TabId;
   label: string;
   caption: string;
+}
+
+interface NavItem {
+  label: string;
+  route: RouteName;
   icon: string;
+}
+
+interface NavGroup {
+  title: string;
+  items: NavItem[];
 }
 
 interface UserRow {
   id: string;
-  name: string;
-  department: string;
+  order: number;
+  username: string;
+  fullName: string;
   email: string;
-  lastLogin: string;
-  module: string;
+  role: string;
   routeName: RouteName;
 }
 
-interface ModuleCard {
+interface ProductField {
   id: string;
-  title: string;
-  module: string;
-  count: number;
-  description: string;
-  routeName: RouteName;
-  icon: string;
-  linkLabel: string;
+  label: string;
+  placeholder: string;
 }
 
-interface IntegrationCard {
+interface IntegrationRow {
   id: string;
-  title: string;
-  status: string;
-  note: string;
-  routeName: RouteName;
-  icon: string;
-  linkLabel: string;
+  name: string;
+  server: string;
+  port: string;
+  baseDn: string;
+  username: string;
 }
+
+const router = useRouter();
+
+const navGroups: NavGroup[] = [
+  {
+    title: 'Ana Sayfa',
+    items: [
+      { label: 'Ana Sayfa', route: 'home', icon: '🏠' }
+    ]
+  },
+  {
+    title: 'Envanter',
+    items: [
+      { label: 'Envanter Takip', route: 'inventory-tracking', icon: '📦' },
+      { label: 'Lisans Takip', route: 'license-tracking', icon: '🪪' },
+      { label: 'Yazıcı Takip', route: 'printer-tracking', icon: '🖨️' },
+      { label: 'Stok Takip', route: 'stock-tracking', icon: '📊' }
+    ]
+  },
+  {
+    title: 'İşlemler',
+    items: [
+      { label: 'Talep Takip', route: 'request-tracking', icon: '🗂️' },
+      { label: 'Bilgiler', route: 'knowledge-base', icon: '📘' },
+      { label: 'Hurda', route: 'scrap-management', icon: '♻️' }
+    ]
+  },
+  {
+    title: 'Ayarlar',
+    items: [
+      { label: 'Profil', route: 'profile', icon: '👤' },
+      { label: 'Admin Paneli', route: 'admin-panel', icon: '🛠️' },
+      { label: 'Kayıtlar', route: 'records', icon: '🧾' }
+    ]
+  }
+];
 
 const tabItems: TabItem[] = [
-  {
-    id: 'users',
-    label: 'Kullanıcı Yönetimi',
-    caption: 'Roller ve ekipler',
-    icon: '👥'
-  },
-  {
-    id: 'modules',
-    label: 'Ürün Modülleri',
-    caption: 'Katalog ve stoklar',
-    icon: '🧩'
-  },
-  {
-    id: 'integrations',
-    label: 'Bağlantılar',
-    caption: 'LDAP & API ayarları',
-    icon: '🔗'
-  }
+  { id: 'users', label: 'Kullanıcı', caption: 'Yetkilendirme' },
+  { id: 'product', label: 'Ürün Ekle', caption: 'Envanter' },
+  { id: 'connections', label: 'Bağlantılar', caption: 'LDAP' }
 ];
 
 const activeTab = ref<TabId>('users');
 const searchQuery = ref('');
 
-const userRows: UserRow[] = [];
+const userRows: UserRow[] = [
+  {
+    id: '1',
+    order: 1,
+    username: 'admin',
+    fullName: 'Sistem Yöneticisi',
+    email: 'admin@ornekfirma.com',
+    role: 'Admin',
+    routeName: 'profile'
+  }
+];
 
-const moduleCards: ModuleCard[] = [];
+const productFields: ProductField[] = [
+  { id: 'usage-area', label: 'Kullanım Alanı', placeholder: 'Örn. Ofis / Üretim' },
+  { id: 'license-name', label: 'Lisans Adı', placeholder: 'Örn. Microsoft 365' },
+  { id: 'category', label: 'Bilgi Kategorisi', placeholder: 'Yazılım / Donanım' },
+  { id: 'factory', label: 'Fabrika', placeholder: 'Örn. İstanbul' },
+  { id: 'hardware-type', label: 'Donanım Tipi', placeholder: 'Laptop / Yazıcı' },
+  { id: 'brand', label: 'Marka', placeholder: 'Örn. Lenovo' },
+  { id: 'model', label: 'Model', placeholder: 'Örn. ThinkPad T14' }
+];
 
-const integrationCards: IntegrationCard[] = [];
+const integrationRows: IntegrationRow[] = [];
 
 const filteredUsers = computed(() => {
   const query = searchQuery.value.trim().toLowerCase();
@@ -251,15 +303,27 @@ const filteredUsers = computed(() => {
 
   return userRows.filter((user) => {
     return (
-      user.name.toLowerCase().includes(query) ||
-      user.department.toLowerCase().includes(query) ||
+      user.username.toLowerCase().includes(query) ||
+      user.fullName.toLowerCase().includes(query) ||
       user.email.toLowerCase().includes(query) ||
-      user.module.toLowerCase().includes(query)
+      user.role.toLowerCase().includes(query)
     );
   });
 });
 
+const activeUserCount = computed(() => userRows.length);
 const isSearchDisabled = computed(() => activeTab.value !== 'users');
+
+const toolbarButtonLabel = computed(() => {
+  switch (activeTab.value) {
+    case 'product':
+      return 'Kaydet';
+    case 'connections':
+      return 'Bağlantı Ekle';
+    default:
+      return 'Yeni Kullanıcı';
+  }
+});
 
 watch(activeTab, (tab) => {
   if (tab !== 'users') {
@@ -267,121 +331,248 @@ watch(activeTab, (tab) => {
   }
 });
 
-const primaryActionLabel = computed(() => {
+const handleToolbarAction = () => {
   switch (activeTab.value) {
-    case 'modules':
-      return 'Katalogu Güncelle';
-    case 'integrations':
-      return 'Bağlantı Ekle';
+    case 'product':
+      router.push({ name: 'inventory-tracking' });
+      break;
+    case 'connections':
+      router.push({ name: 'knowledge-base' });
+      break;
     default:
-      return 'Yeni Kullanıcı';
+      router.push({ name: 'profile' });
+      break;
   }
-});
+};
 
-const primaryActionRoute = computed<RouteLocationRaw>(() => {
-  switch (activeTab.value) {
-    case 'modules':
-      return { name: 'inventory-tracking' };
-    case 'integrations':
-      return { name: 'knowledge-base' };
-    default:
-      return { name: 'profile' };
-  }
-});
+const goToProfile = (routeName: RouteName) => {
+  router.push({ name: routeName });
+};
+
+const configureIntegration = (integration: IntegrationRow) => {
+  console.info('Entegrasyon yapılandırması', integration);
+  router.push({ name: 'records' });
+};
 </script>
 
 <style scoped>
-.admin-page {
+.admin-layout {
   display: grid;
+  grid-template-columns: 280px 1fr;
   gap: 2.5rem;
+  min-height: calc(100vh - 4rem);
+  padding: 2.5rem 2rem;
+  background: linear-gradient(180deg, #e0f2ff 0%, #f8fbff 100%);
   color: #0f172a;
 }
 
-.panel-card {
-  background: #ffffff;
-  border-radius: 28px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: 0 32px 70px rgba(15, 23, 42, 0.12);
-  padding: 2.5rem;
+.side-nav {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 26px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 50px rgba(37, 99, 235, 0.1);
+  padding: 1.75rem 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.nav-group {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.nav-title {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  background: rgba(37, 99, 235, 0.14);
+  color: #1d4ed8;
+}
+
+.nav-link.active {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.15), rgba(59, 130, 246, 0.2));
+  color: #1e3a8a;
+}
+
+.nav-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  background: rgba(37, 99, 235, 0.12);
+  font-size: 1rem;
+}
+
+.panel-area {
   display: grid;
   gap: 2rem;
+}
+
+.page-hero {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 26px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
+  padding: 2rem 2.25rem;
+}
+
+.hero-copy {
+  max-width: 520px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.page-hero h1 {
+  margin: 0;
+  font-size: 2.15rem;
+}
+
+.page-hero p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.hero-stat {
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.16), rgba(59, 130, 246, 0.16));
+  border-radius: 20px;
+  padding: 1.25rem 1.6rem;
+  display: grid;
+  gap: 0.35rem;
+  align-content: center;
+  color: #0f172a;
+}
+
+.stat-label {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #1e3a8a;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stat-value {
+  margin: 0;
+  font-size: 2.25rem;
+  font-weight: 700;
+}
+
+.stat-link {
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.panel-card {
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 36px 70px rgba(15, 23, 42, 0.14);
+  padding: 2.25rem;
+  display: grid;
+  gap: 1.75rem;
 }
 
 .panel-header {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  align-items: flex-start;
-  gap: 1.75rem;
-}
-
-.panel-heading {
-  display: grid;
-  gap: 0.85rem;
-  max-width: 580px;
-}
-
-.panel-badge {
-  display: inline-flex;
+  gap: 1.5rem;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.3rem 0.75rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  background: rgba(37, 99, 235, 0.12);
-  color: #1d4ed8;
-  font-weight: 700;
 }
 
-.panel-heading h1 {
-  margin: 0;
-  font-size: 2.3rem;
-}
-
-.panel-intro {
-  margin: 0;
-  font-size: 1.02rem;
-  color: #475569;
-  line-height: 1.6;
-}
-
-.panel-actions {
+.tab-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
-  align-items: center;
+  gap: 0.75rem;
 }
 
-.primary-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.75rem 1.65rem;
+.tab-button {
+  border: none;
   border-radius: 999px;
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  color: #f8fafc;
+  padding: 0.75rem 1.4rem;
+  background: rgba(226, 232, 240, 0.6);
+  color: #0f172a;
   font-weight: 600;
-  text-decoration: none;
-  box-shadow: 0 20px 36px rgba(37, 99, 235, 0.3);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  min-width: 150px;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
-.primary-action:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 26px 44px rgba(37, 99, 235, 0.32);
+.tab-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px rgba(37, 99, 235, 0.16);
+}
+
+.tab-button.active {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.15), rgba(125, 211, 252, 0.25));
+  color: #1e3a8a;
+  box-shadow: 0 24px 42px rgba(37, 99, 235, 0.24);
+}
+
+.tab-caption {
+  font-size: 0.78rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.panel-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .search-field {
   display: inline-flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.6rem;
   padding: 0.7rem 1rem;
   border-radius: 16px;
-  background: rgba(248, 250, 252, 0.9);
   border: 1px solid rgba(148, 163, 184, 0.3);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  background: rgba(248, 250, 252, 0.9);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
 .search-field input {
@@ -390,91 +581,64 @@ const primaryActionRoute = computed<RouteLocationRaw>(() => {
   outline: none;
   font-size: 0.95rem;
   color: #0f172a;
-  min-width: 220px;
+  min-width: 200px;
 }
 
 .search-field input::placeholder {
-  color: rgba(100, 116, 139, 0.8);
+  color: rgba(100, 116, 139, 0.7);
 }
 
 .search-field.disabled {
-  opacity: 0.6;
+  opacity: 0.55;
 }
 
 .search-field.disabled input {
   cursor: not-allowed;
 }
 
-.search-icon {
-  font-size: 1.1rem;
-}
-
-.panel-tabs {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-.panel-tab {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 1rem 1.1rem;
-  border-radius: 18px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(248, 250, 252, 0.9);
-  cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.panel-tab:hover {
-  transform: translateY(-2px);
-  border-color: rgba(37, 99, 235, 0.4);
-  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.18);
-}
-
-.panel-tab.active {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.16), rgba(37, 99, 235, 0.12));
-  border-color: rgba(37, 99, 235, 0.45);
-  box-shadow: 0 20px 36px rgba(37, 99, 235, 0.22);
-}
-
-.tab-icon {
-  width: 2.4rem;
-  height: 2.4rem;
-  border-radius: 16px;
-  background: rgba(59, 130, 246, 0.18);
-  display: grid;
-  place-items: center;
-  font-size: 1.25rem;
-}
-
-.tab-text {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.3rem;
-}
-
-.tab-label {
+.toolbar-button {
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #f8fafc;
   font-weight: 600;
+  padding: 0.75rem 1.65rem;
+  cursor: pointer;
+  box-shadow: 0 22px 38px rgba(37, 99, 235, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.tab-caption {
-  font-size: 0.82rem;
-  color: #475569;
+.toolbar-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 46px rgba(37, 99, 235, 0.3);
 }
 
 .panel-body {
-  display: block;
+  display: grid;
+  gap: 1.5rem;
 }
 
-.tab-panel {
-  background: rgba(248, 250, 252, 0.9);
-  border-radius: 22px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  padding: 1.5rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 22px 38px rgba(15, 23, 42, 0.08);
+.tab-copy {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.tab-copy h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.tab-copy p {
+  margin: 0;
+  color: #475569;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(248, 250, 252, 0.95);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
 .admin-table {
@@ -487,196 +651,107 @@ const primaryActionRoute = computed<RouteLocationRaw>(() => {
 .admin-table td {
   padding: 0.9rem 1.1rem;
   text-align: left;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.empty-row {
-  text-align: center;
-  padding: 2rem 0;
-  color: #64748b;
-  font-weight: 500;
-  background: rgba(241, 245, 249, 0.6);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .admin-table thead th {
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #475569;
   background: rgba(226, 232, 240, 0.4);
 }
 
-.user-name {
-  font-weight: 600;
+.admin-table tbody tr:last-child td {
+  border-bottom: none;
 }
 
-.table-link {
+.actions {
+  text-align: right;
+}
+
+.link-button {
+  border: none;
+  background: none;
   color: #2563eb;
   font-weight: 600;
-}
-
-.module-grid,
-.integration-grid {
-  list-style: none;
-  margin: 0;
+  cursor: pointer;
   padding: 0;
-  display: grid;
-  gap: 1.2rem;
 }
 
-.module-card,
-.integration-card {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 1rem;
-  align-items: center;
-  padding: 1.4rem 1.6rem;
-  border-radius: 18px;
-  background: #ffffff;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
-}
-
-.module-icon,
-.integration-icon {
-  width: 2.8rem;
-  height: 2.8rem;
-  border-radius: 18px;
-  background: rgba(59, 130, 246, 0.16);
-  display: grid;
-  place-items: center;
-  font-size: 1.35rem;
-}
-
-.module-label,
-.integration-label {
-  margin: 0;
-  font-weight: 600;
-  font-size: 1.05rem;
-}
-
-.module-meta,
-.integration-status {
-  margin: 0.25rem 0 0;
-  color: #475569;
-  font-size: 0.9rem;
-}
-
-.module-note,
-.integration-note {
-  margin: 0.45rem 0 0;
-  color: #1f2937;
-  font-size: 0.92rem;
-  line-height: 1.5;
-}
-
-.module-link,
-.integration-link {
-  color: #2563eb;
-  font-weight: 600;
-  text-decoration: none;
-  font-size: 0.9rem;
+.link-button:hover,
+.link-button:focus-visible {
+  text-decoration: underline;
 }
 
 .empty-state {
-  margin: 0;
-  padding: 2.25rem;
   text-align: center;
-  border-radius: 20px;
-  border: 1px dashed rgba(148, 163, 184, 0.5);
-  color: #475569;
-  background: rgba(248, 250, 252, 0.9);
+  padding: 2rem 0;
+  color: #64748b;
   font-weight: 500;
 }
 
-.workflow-card {
-  background: #ffffff;
-  border-radius: 26px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  padding: 2.25rem;
-  box-shadow: 0 28px 52px rgba(15, 23, 42, 0.1);
+.product-form {
   display: grid;
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem 1.5rem;
 }
 
-.workflow-card header h2 {
-  margin: 0 0 0.6rem;
-  font-size: 1.6rem;
-}
-
-.workflow-card header p {
-  margin: 0;
-  color: #475569;
-  line-height: 1.6;
-}
-
-.workflow-steps {
-  margin: 0;
-  padding-left: 1.2rem;
+.form-field {
   display: grid;
-  gap: 1rem;
-  color: #1f2937;
-  line-height: 1.6;
+  gap: 0.45rem;
 }
 
-.workflow-steps a {
-  color: #2563eb;
+.form-field label {
   font-weight: 600;
+  color: #1e293b;
 }
 
-@media (max-width: 1024px) {
-  .panel-card {
-    padding: 2rem;
-  }
+.form-field input {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.7rem 0.9rem;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.9);
+}
 
-  .panel-tabs {
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  }
-
-  .module-card,
-  .integration-card {
+@media (max-width: 1100px) {
+  .admin-layout {
     grid-template-columns: 1fr;
-    text-align: left;
+  }
+
+  .side-nav {
+    order: 2;
+  }
+
+  .panel-area {
+    order: 1;
   }
 }
 
 @media (max-width: 720px) {
-  .panel-header {
+  .page-hero {
     flex-direction: column;
   }
 
-  .panel-actions {
-    width: 100%;
-    justify-content: space-between;
-  }
-
-  .search-field input {
-    min-width: 0;
-    width: 100%;
-  }
-}
-
-@media (max-width: 560px) {
-  .panel-card {
-    padding: 1.6rem;
-  }
-
-  .panel-tabs {
-    grid-template-columns: 1fr;
-  }
-
-  .panel-actions {
+  .panel-header {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .primary-action,
-  .search-field {
+  .panel-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-field,
+  .toolbar-button {
     width: 100%;
   }
 
-  .search-field {
-    justify-content: flex-start;
+  .tab-list {
+    width: 100%;
+    justify-content: space-between;
   }
 }
 </style>

--- a/frontend/src/views/InventoryTrackingView.vue
+++ b/frontend/src/views/InventoryTrackingView.vue
@@ -1,23 +1,21 @@
 <template>
-  <section class="workspace-page" aria-labelledby="inventory-title">
-    <article class="workspace-hero">
-      <header class="hero-header">
-        <div class="hero-heading">
-          <span class="hero-badge">Zimmet Merkezi</span>
-          <h1 id="inventory-title">Envanter Takip</h1>
-          <p class="hero-intro">
-            Bilgi işlem envanterinizi lokasyon, departman ve zimmet alanına göre yönetin. Stok
-            hareketlerinden gelen cihazları hızla sahiplerine atayın ve lisans, yazıcı, stok modülleriyle
-            tam entegrasyon sağlayın.
-          </p>
+  <section class="inventory-page" aria-labelledby="inventory-page-title">
+    <article class="inventory-hero">
+      <div class="hero-copy">
+        <span class="hero-eyebrow">Envanter Yönetimi</span>
+        <h1 id="inventory-page-title">Envanter Listesi</h1>
+        <p>
+          Envanterdeki cihazların sorumlularını, durumlarını ve bağlı oldukları modülleri tek ekrandan
+          görüntüleyin. Talep, stok ve kayıt akışlarıyla entegre şekilde yönetin.
+        </p>
+        <div class="hero-links">
+          <RouterLink :to="{ name: 'request-tracking' }">Talep Takip</RouterLink>
+          <RouterLink :to="{ name: 'stock-tracking' }">Stok İşlemleri</RouterLink>
+          <RouterLink :to="{ name: 'records' }">Kayıt Arşivi</RouterLink>
         </div>
-        <div class="hero-actions">
-          <RouterLink :to="{ name: 'stock-tracking' }" class="primary-action">Stok aktarımını incele</RouterLink>
-          <RouterLink :to="{ name: 'request-tracking' }" class="secondary-link">Talep kuyruğuna dön</RouterLink>
-        </div>
-      </header>
-      <dl class="hero-metrics">
-        <div v-for="metric in heroMetrics" :key="metric.id">
+      </div>
+      <dl class="hero-metrics" aria-label="Envanter özetleri">
+        <div v-for="metric in metrics" :key="metric.id">
           <dt>{{ metric.label }}</dt>
           <dd>{{ metric.value }}</dd>
           <p class="metric-note">{{ metric.note }}</p>
@@ -25,194 +23,1128 @@
       </dl>
     </article>
 
-    <div class="workspace-grid columns-2">
-      <article class="workspace-card table-card" aria-labelledby="inventory-summary">
-        <header>
-          <h2 id="inventory-summary">Son Eklenen Cihazlar</h2>
-          <p>Stoktan gelen ve zimmetlenmeyi bekleyen cihazların listesi.</p>
-        </header>
-        <table>
+    <article class="inventory-card" aria-labelledby="inventory-table-title">
+      <header class="inventory-card-header">
+        <div>
+          <h2 id="inventory-table-title">Cihazlar</h2>
+          <p>IFS kayıt numaraları, sorumlular ve marka/model bilgileriyle tüm envanter kartları.</p>
+        </div>
+        <div class="inventory-card-actions">
+          <button type="button" class="action primary" @click="openAddInventoryModal">+ Ekle</button>
+          <button type="button" class="action outline" @click="showFaultyRecords">Arızalı Durum</button>
+        </div>
+      </header>
+
+      <div class="inventory-toolbar">
+        <nav class="inventory-segments" aria-label="Envanter durum filtreleri">
+          <button
+            v-for="segment in segmentOptions"
+            :key="segment.id"
+            type="button"
+            class="segment-button"
+            :class="{ active: selectedSegment === segment.id }"
+            @click="selectedSegment = segment.id"
+          >
+            <span>{{ segment.label }}</span>
+            <span class="segment-count" aria-hidden="true">{{ segment.count }}</span>
+          </button>
+        </nav>
+        <div class="inventory-search">
+          <label class="sr-only" for="inventory-search-input">Envanter ara</label>
+          <input
+            id="inventory-search-input"
+            v-model="searchQuery"
+            type="search"
+            name="q"
+            placeholder="Ara..."
+          />
+          <button type="button" class="action subtle" @click="toggleFilters">Filtrele</button>
+        </div>
+      </div>
+
+      <transition name="drawer">
+        <aside v-if="filtersOpen" class="filter-panel" aria-label="Envanter filtreleri">
+          <header>
+            <h3>Filtreler</h3>
+            <p>Fabrika ve departman bazında listeyi daraltın.</p>
+          </header>
+          <form @submit.prevent class="filter-form">
+            <label for="factory-select">Fabrika</label>
+            <select id="factory-select" v-model="appliedFilters.factory">
+              <option v-for="factory in factories" :key="factory" :value="factory">{{ factory }}</option>
+            </select>
+
+            <label for="department-select">Departman</label>
+            <select id="department-select" v-model="appliedFilters.department">
+              <option v-for="department in departments" :key="department" :value="department">
+                {{ department }}
+              </option>
+            </select>
+
+            <div class="filter-actions">
+              <button type="button" class="action" @click="resetFilters">Temizle</button>
+              <button type="button" class="action outline" @click="toggleFilters">Kapat</button>
+            </div>
+          </form>
+        </aside>
+      </transition>
+
+      <div class="table-wrapper" role="region" aria-live="polite">
+        <table class="inventory-table">
           <thead>
             <tr>
-              <th scope="col">Varlık</th>
+              <th scope="col">Envanter No</th>
+              <th scope="col">Fabrika</th>
               <th scope="col">Departman</th>
-              <th scope="col">Durum</th>
-              <th scope="col">Güncelleme</th>
+              <th scope="col">Sorumlu</th>
+              <th scope="col">Marka / Model</th>
+              <th scope="col" class="actions-header">İşlemler</th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="item in inventoryItems" :key="item.assetId">
-              <td>
-                <span class="summary-title">{{ item.name }}</span>
-                <p class="summary-meta">{{ item.assetId }}</p>
+            <tr v-for="record in filteredRecords" :key="record.id">
+              <td data-title="Envanter No">
+                <span class="cell-title">{{ record.inventoryNo }}</span>
+                <span class="cell-meta">{{ record.statusLabel }}</span>
               </td>
-              <td>{{ item.department }}</td>
-              <td>
-                <span class="status-chip">{{ statusLabels[item.status] }}</span>
+              <td data-title="Fabrika">{{ record.factory }}</td>
+              <td data-title="Departman">{{ record.department }}</td>
+              <td data-title="Sorumlu">
+                <span class="cell-title">{{ record.responsible }}</span>
+                <span class="cell-meta">{{ record.responsibleRole }}</span>
               </td>
-              <td>{{ item.updatedAt }}</td>
+              <td data-title="Marka / Model">
+                <span class="cell-title">{{ record.brand }}</span>
+                <span class="cell-meta">{{ record.model }}</span>
+              </td>
+              <td data-title="İşlemler" class="actions-cell">
+                <label class="sr-only" :for="`inventory-action-${record.id}`">{{ record.inventoryNo }} işlemleri</label>
+                <select
+                  :id="`inventory-action-${record.id}`"
+                  :value="selectedActions[record.id] ?? ''"
+                  @change="(event) => handleActionChange(record, (event.target as HTMLSelectElement).value)"
+                >
+                  <option value="" disabled>Seçiniz...</option>
+                  <option value="detail">Detaya git</option>
+                  <option value="handover">Zimmet güncelle</option>
+                  <option value="faulty">Arıza bildir</option>
+                  <option value="history">Kayıtlara aç</option>
+                </select>
+              </td>
+            </tr>
+            <tr v-if="filteredRecords.length === 0">
+              <td colspan="6" class="empty-state">Seçili filtrelerde kayıt bulunamadı.</td>
             </tr>
           </tbody>
         </table>
-      </article>
-
-      <article class="workspace-card" aria-labelledby="inventory-links">
-        <header>
-          <h2 id="inventory-links">İlişkili Modüller</h2>
-          <p>Envanter hareketlerini destekleyen diğer sayfalara yönelin.</p>
-        </header>
-        <div class="quick-actions">
-          <RouterLink v-for="link in relatedLinks" :key="link.title" :to="link.to">
-            {{ link.title }} <span aria-hidden="true">→</span>
-          </RouterLink>
-        </div>
-        <footer>
-          <RouterLink :to="{ name: 'knowledge-base' }" class="card-link">Zimmet prosedürlerini aç</RouterLink>
-        </footer>
-      </article>
-
-      <article class="workspace-card" aria-labelledby="inventory-log">
-        <header>
-          <h2 id="inventory-log">Giriş / Çıkış Kayıtları</h2>
-          <p>Envanterdeki değişikliklerin kronolojisi ve ilgili bağlantılar.</p>
-        </header>
-        <ul class="timeline">
-          <li v-for="entry in movementLog" :key="entry.id" class="timeline-entry">
-            <span class="timeline-dot" aria-hidden="true"></span>
-            <div class="timeline-content">
-              <p class="timeline-title">{{ entry.text }}</p>
-              <p class="timeline-meta">{{ entry.time }}</p>
-              <RouterLink v-if="entry.relatedRoute" :to="entry.relatedRoute" class="timeline-link">
-                Detaya git
-              </RouterLink>
-            </div>
-          </li>
-        </ul>
-      </article>
-    </div>
-
-    <article class="workflow-card">
-      <h2>Zimmet Döngüsü</h2>
-      <ol class="workflow-steps">
-        <li>
-          Stoktan gelen cihazlar zimmetlenmeden önce <RouterLink :to="{ name: 'request-tracking' }">Talep</RouterLink>
-          onaylarına bağlanır.
-        </li>
-        <li>
-          Lisans ve yazıcı eşleştirmeleri tamamlandığında
-          <RouterLink :to="{ name: 'license-tracking' }">Lisans</RouterLink> ve
-          <RouterLink :to="{ name: 'printer-tracking' }">Yazıcı</RouterLink> modülleri bilgilendirilir.
-        </li>
-        <li>
-          Tüm hareketler <RouterLink :to="{ name: 'records' }">Kayıtlar</RouterLink> paneline aktarılır ve
-          ekiplerle paylaşılır.
-        </li>
-      </ol>
+      </div>
     </article>
+
+    <article class="inventory-links" aria-label="Modüller arası bağlantılar">
+      <h2>Modüllerle bağlantıda kalın</h2>
+      <p>Envanter kartlarını talep, lisans ve yazıcı modülleriyle ilişkilendirerek süreçleri izleyin.</p>
+      <ul class="link-grid">
+        <li v-for="link in crossModuleLinks" :key="link.title">
+          <RouterLink :to="link.to">{{ link.title }} <span aria-hidden="true">→</span></RouterLink>
+        </li>
+      </ul>
+    </article>
+
+    <transition name="backdrop">
+      <div
+        v-if="isAddModalOpen"
+        class="modal-backdrop"
+        role="presentation"
+        @click="closeAddInventoryModal"
+      >
+        <transition name="modal">
+          <div
+            v-if="isAddModalOpen"
+            class="modal-card"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="add-inventory-title"
+            aria-describedby="add-inventory-description"
+            tabindex="-1"
+            @keydown.esc="closeAddInventoryModal"
+            @click.stop
+          >
+            <header class="modal-header">
+              <div>
+                <h2 id="add-inventory-title">Envanter Ekle</h2>
+                <p id="add-inventory-description">
+                  Yeni cihaz bilgilerini girin, sorumluyu seçin ve stok kayıtlarıyla ilişkilendirin.
+                </p>
+              </div>
+              <button type="button" class="modal-close" aria-label="Pencereyi kapat" @click="closeAddInventoryModal">
+                ×
+              </button>
+            </header>
+
+            <form class="modal-form" @submit.prevent="submitNewInventory">
+              <div class="modal-grid">
+                <label class="form-field">
+                  <span>Envanter No</span>
+                  <input v-model="newInventoryForm.inventoryNo" type="text" placeholder="ENV-000123" />
+                </label>
+                <label class="form-field">
+                  <span>Bilgisayar Adı</span>
+                  <input v-model="newInventoryForm.computerName" type="text" placeholder="PC-OFIS-01" />
+                </label>
+                <label class="form-field">
+                  <span>Fabrika</span>
+                  <select v-model="newInventoryForm.factory">
+                    <option value="" disabled>Seçiniz…</option>
+                    <option v-for="factory in factoryChoices" :key="factory" :value="factory">{{ factory }}</option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Departman</span>
+                  <select v-model="newInventoryForm.department">
+                    <option value="" disabled>Seçiniz…</option>
+                    <option v-for="department in departmentChoices" :key="department" :value="department">
+                      {{ department }}
+                    </option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Donanım Tipi</span>
+                  <select v-model="newInventoryForm.hardwareType">
+                    <option value="" disabled>Seçiniz…</option>
+                    <option v-for="hardware in hardwareTypes" :key="hardware" :value="hardware">{{ hardware }}</option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Sorumlu Personel</span>
+                  <select v-model="newInventoryForm.responsible">
+                    <option value="" disabled>Seçiniz…</option>
+                    <option v-for="person in personnelOptions" :key="person.id" :value="person.id">
+                      {{ person.name }} - {{ person.role }}
+                    </option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Marka</span>
+                  <select v-model="newInventoryForm.brand">
+                    <option value="" disabled>Seçiniz…</option>
+                    <option v-for="brand in brandOptions" :key="brand" :value="brand">{{ brand }}</option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Model</span>
+                  <select v-model="newInventoryForm.model">
+                    <option value="" disabled>Seçiniz…</option>
+                    <option v-for="model in modelOptions" :key="model" :value="model">{{ model }}</option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Seri No</span>
+                  <input v-model="newInventoryForm.serialNo" type="text" placeholder="SN123456789" />
+                </label>
+                <label class="form-field">
+                  <span>IFS No <small>(zorunlu değil)</small></span>
+                  <input v-model="newInventoryForm.ifsNo" type="text" placeholder="IFS-" />
+                </label>
+                <label class="form-field">
+                  <span>Bağlı Makina No</span>
+                  <input v-model="newInventoryForm.linkedMachineNo" type="text" placeholder="MK-001" />
+                </label>
+                <label class="form-field">
+                  <span>Makina No</span>
+                  <input v-model="newInventoryForm.machineNo" type="text" placeholder="MK-002" />
+                </label>
+                <label class="form-field form-field--textarea">
+                  <span>Açıklama / Notlar</span>
+                  <textarea
+                    v-model="newInventoryForm.notes"
+                    rows="3"
+                    placeholder="Kurulum durumu, özel notlar…"
+                  ></textarea>
+                </label>
+              </div>
+
+              <div class="modal-actions">
+                <button type="submit" class="action primary">Kaydet</button>
+                <button type="button" class="action outline" @click="closeAddInventoryModal">İptal</button>
+              </div>
+            </form>
+          </div>
+        </transition>
+      </div>
+    </transition>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
-import { RouterLink, type RouteLocationRaw } from 'vue-router';
+import { computed, reactive, ref } from 'vue';
+import { RouterLink, useRouter, type RouteLocationRaw } from 'vue-router';
 
-const statusLabels = {
-  assigned: 'Zimmetli',
-  pending: 'Atama Bekliyor',
-  maintenance: 'Bakımda'
-} as const;
+type RouteName =
+  | 'home'
+  | 'inventory-tracking'
+  | 'license-tracking'
+  | 'printer-tracking'
+  | 'stock-tracking'
+  | 'request-tracking'
+  | 'knowledge-base'
+  | 'scrap-management'
+  | 'profile'
+  | 'admin-panel'
+  | 'records';
 
-type InventoryStatus = keyof typeof statusLabels;
+type InventoryState = 'assigned' | 'available' | 'transfer' | 'faulty';
+type SegmentValue = 'all' | InventoryState;
 
-interface HeroMetric {
+interface InventoryRecord {
+  id: string;
+  inventoryNo: string;
+  factory: string;
+  department: string;
+  responsible: string;
+  responsibleRole: string;
+  brand: string;
+  model: string;
+  state: InventoryState;
+  detailRoute: RouteLocationRaw;
+}
+
+interface InventoryTableRow extends InventoryRecord {
+  statusLabel: string;
+}
+
+interface MetricItem {
   id: string;
   label: string;
   value: string;
   note: string;
 }
 
-interface InventoryItem {
-  assetId: string;
-  name: string;
-  department: string;
-  status: InventoryStatus;
-  updatedAt: string;
+interface SegmentOption {
+  id: SegmentValue;
+  label: string;
+  count: number;
 }
 
-interface RelatedLink {
+interface AppliedFilters {
+  factory: string;
+  department: string;
+}
+
+interface CrossModuleLink {
   title: string;
   to: RouteLocationRaw;
 }
 
-interface MovementLogEntry {
-  id: number;
-  time: string;
-  text: string;
-  relatedRoute?: RouteLocationRaw;
-}
+const router = useRouter();
 
-const inventoryItems: InventoryItem[] = [
+const statusLabels: Record<InventoryState, string> = {
+  assigned: 'Zimmetli',
+  available: 'Depoda',
+  transfer: 'Transferde',
+  faulty: 'Arızalı'
+};
+
+const inventoryRecords = ref<InventoryRecord[]>([
   {
-    assetId: 'NB-1042',
-    name: 'Dell Latitude 7440',
+    id: 'INV-1041',
+    inventoryNo: 'IFS-ENV-1041',
+    factory: 'Gebze',
+    department: 'Üretim',
+    responsible: 'Ahmet Demir',
+    responsibleRole: 'Hat Süpervizörü',
+    brand: 'Dell',
+    model: 'Latitude 7440',
+    state: 'assigned',
+    detailRoute: { name: 'request-tracking' }
+  },
+  {
+    id: 'INV-1045',
+    inventoryNo: 'IFS-ENV-1045',
+    factory: 'Ankara',
     department: 'Finans',
-    status: 'assigned',
-    updatedAt: '2 saat önce'
+    responsible: 'Elif Kaya',
+    responsibleRole: 'Finans Uzmanı',
+    brand: 'HP',
+    model: 'ProBook 450 G10',
+    state: 'transfer',
+    detailRoute: { name: 'stock-tracking' }
   },
   {
-    assetId: 'MNT-2034',
-    name: 'LG 27UL500',
-    department: 'Tasarım',
-    status: 'pending',
-    updatedAt: 'Dün'
+    id: 'INV-1038',
+    inventoryNo: 'IFS-ENV-1038',
+    factory: 'İzmir',
+    department: 'Bakım',
+    responsible: 'Mert Yıldız',
+    responsibleRole: 'Tekniker',
+    brand: 'Lenovo',
+    model: 'ThinkPad L15',
+    state: 'faulty',
+    detailRoute: { name: 'scrap-management' }
   },
   {
-    assetId: 'SRV-3012',
-    name: 'HP ProLiant DL380',
-    department: 'Data Center',
-    status: 'maintenance',
-    updatedAt: '3 gün önce'
+    id: 'INV-1022',
+    inventoryNo: 'IFS-ENV-1022',
+    factory: 'Gebze',
+    department: 'Ar-Ge',
+    responsible: 'Selin Uçar',
+    responsibleRole: 'Yazılım Mühendisi',
+    brand: 'Apple',
+    model: 'MacBook Pro 14"',
+    state: 'available',
+    detailRoute: { name: 'license-tracking' }
   }
+]);
+
+const searchQuery = ref('');
+const selectedSegment = ref<SegmentValue>('all');
+const filtersOpen = ref(false);
+const appliedFilters = reactive<AppliedFilters>({ factory: 'Tümü', department: 'Tümü' });
+const selectedActions = reactive<Record<string, string>>({});
+
+const factories = ['Tümü', 'Gebze', 'İzmir', 'Ankara'];
+const departments = ['Tümü', 'Üretim', 'Ar-Ge', 'Finans', 'Bakım'];
+const factoryChoices = factories.filter((factory) => factory !== 'Tümü');
+const departmentChoices = departments.filter((department) => department !== 'Tümü');
+
+const crossModuleLinks: CrossModuleLink[] = [
+  { title: 'Talep kuyruğuna bağlan', to: { name: 'request-tracking' } },
+  { title: 'Stok girişlerini kontrol et', to: { name: 'stock-tracking' } },
+  { title: 'Lisans eşlemesini incele', to: { name: 'license-tracking' } },
+  { title: 'Kayıt arşivine git', to: { name: 'records' } }
 ];
 
-const heroMetrics = computed<HeroMetric[]>(() => {
-  const assigned = inventoryItems.filter((item) => item.status === 'assigned').length;
-  const pending = inventoryItems.filter((item) => item.status === 'pending').length;
-  const maintenance = inventoryItems.filter((item) => item.status === 'maintenance').length;
+const metrics = computed<MetricItem[]>(() => {
+  const totals = inventoryRecords.value.reduce(
+    (acc, record) => {
+      acc[record.state] += 1;
+      return acc;
+    },
+    {
+      assigned: 0,
+      available: 0,
+      transfer: 0,
+      faulty: 0
+    } as Record<InventoryState, number>
+  );
 
   return [
-    { id: 'total', label: 'Toplam Kayıt', value: String(inventoryItems.length), note: 'Aktif envanter kartı' },
-    { id: 'assigned', label: 'Zimmetli', value: String(assigned), note: 'Teslim edilmiş cihaz' },
-    { id: 'pending', label: 'Atama Bekliyor', value: String(pending), note: 'Zimmet planı bekleyen' },
-    { id: 'maintenance', label: 'Bakımda', value: String(maintenance), note: 'Servis sürecindeki varlık' }
+    { id: 'total', label: 'Toplam Kayıt', value: String(inventoryRecords.value.length), note: 'Aktif envanter' },
+    { id: 'assigned', label: 'Zimmetli', value: String(totals.assigned), note: 'Teslim edilmiş cihaz' },
+    { id: 'transfer', label: 'Transferde', value: String(totals.transfer), note: 'Atama bekleyen' },
+    { id: 'faulty', label: 'Arızalı', value: String(totals.faulty), note: 'İyileştirme bekleyen' }
   ];
 });
 
-const relatedLinks: RelatedLink[] = [
-  { title: 'Stok Takip', to: { name: 'stock-tracking' } },
-  { title: 'Lisans Takip', to: { name: 'license-tracking' } },
-  { title: 'Yazıcı Takip', to: { name: 'printer-tracking' } }
+const segmentOptions = computed<SegmentOption[]>(() => {
+  const baseCounts = inventoryRecords.value.reduce(
+    (acc, record) => {
+      acc[record.state] += 1;
+      return acc;
+    },
+    {
+      assigned: 0,
+      available: 0,
+      transfer: 0,
+      faulty: 0
+    } as Record<InventoryState, number>
+  );
+
+  return [
+    { id: 'all', label: 'Tümü', count: inventoryRecords.value.length },
+    { id: 'assigned', label: 'Zimmetli', count: baseCounts.assigned },
+    { id: 'available', label: 'Depoda', count: baseCounts.available },
+    { id: 'transfer', label: 'Transferde', count: baseCounts.transfer },
+    { id: 'faulty', label: 'Arızalı', count: baseCounts.faulty }
+  ];
+});
+
+const filteredRecords = computed<InventoryTableRow[]>(() => {
+  const query = searchQuery.value.trim().toLowerCase();
+
+  return inventoryRecords.value
+    .filter((record) => (selectedSegment.value === 'all' ? true : record.state === selectedSegment.value))
+    .filter((record) =>
+      appliedFilters.factory === 'Tümü' ? true : record.factory.toLowerCase() === appliedFilters.factory.toLowerCase()
+    )
+    .filter((record) =>
+      appliedFilters.department === 'Tümü'
+        ? true
+        : record.department.toLowerCase() === appliedFilters.department.toLowerCase()
+    )
+    .filter((record) => {
+      if (!query) {
+        return true;
+      }
+
+      return [
+        record.inventoryNo,
+        record.factory,
+        record.department,
+        record.responsible,
+        record.brand,
+        record.model
+      ]
+        .join(' ')
+        .toLowerCase()
+        .includes(query);
+    })
+    .map((record) => ({
+      ...record,
+      statusLabel: statusLabels[record.state]
+    }));
+});
+
+const toggleFilters = () => {
+  filtersOpen.value = !filtersOpen.value;
+};
+
+const resetFilters = () => {
+  appliedFilters.factory = 'Tümü';
+  appliedFilters.department = 'Tümü';
+};
+
+const personnelOptions = [
+  { id: 'ahmet-demir', name: 'Ahmet Demir', role: 'Hat Süpervizörü' },
+  { id: 'elif-kaya', name: 'Elif Kaya', role: 'Finans Uzmanı' },
+  { id: 'selin-ucar', name: 'Selin Uçar', role: 'Yazılım Mühendisi' },
+  { id: 'mert-yildiz', name: 'Mert Yıldız', role: 'Tekniker' }
 ];
 
-const movementLog: MovementLogEntry[] = [
-  {
-    id: 1,
-    time: 'Bugün 09:24',
-    text: 'NB-1042 cihazı stoktan teslim alındı ve Finans departmanına zimmetlendi.',
-    relatedRoute: { name: 'stock-tracking' }
-  },
-  {
-    id: 2,
-    time: 'Dün 16:17',
-    text: 'LG 27UL500 monitörü için lisans eşleştirmesi tamamlandı.',
-    relatedRoute: { name: 'license-tracking' }
-  },
-  {
-    id: 3,
-    time: 'Dün 10:05',
-    text: 'SRV-3012 cihazı bakım için talep modülüne aktarıldı.'
+const hardwareTypes = ['Laptop', 'Masaüstü', 'Sunucu', 'Endüstriyel Panel'];
+const brandOptions = ['Dell', 'HP', 'Lenovo', 'Apple', 'Siemens'];
+const modelOptions = ['Latitude 7440', 'ProBook 450 G10', 'ThinkPad L15', 'MacBook Pro 14"', 'IPC 477E'];
+
+const isAddModalOpen = ref(false);
+
+const newInventoryForm = reactive({
+  inventoryNo: '',
+  computerName: '',
+  factory: '',
+  department: '',
+  hardwareType: '',
+  responsible: '',
+  brand: '',
+  model: '',
+  serialNo: '',
+  ifsNo: '',
+  linkedMachineNo: '',
+  machineNo: '',
+  notes: ''
+});
+
+const resetNewInventoryForm = () => {
+  newInventoryForm.inventoryNo = '';
+  newInventoryForm.computerName = '';
+  newInventoryForm.factory = '';
+  newInventoryForm.department = '';
+  newInventoryForm.hardwareType = '';
+  newInventoryForm.responsible = '';
+  newInventoryForm.brand = '';
+  newInventoryForm.model = '';
+  newInventoryForm.serialNo = '';
+  newInventoryForm.ifsNo = '';
+  newInventoryForm.linkedMachineNo = '';
+  newInventoryForm.machineNo = '';
+  newInventoryForm.notes = '';
+};
+
+const openAddInventoryModal = () => {
+  resetNewInventoryForm();
+  isAddModalOpen.value = true;
+};
+
+const closeAddInventoryModal = () => {
+  isAddModalOpen.value = false;
+  resetNewInventoryForm();
+};
+
+const submitNewInventory = () => {
+  const responsible = personnelOptions.find((person) => person.id === newInventoryForm.responsible);
+
+  const newRecord: InventoryRecord = {
+    id: `INV-${Date.now()}`,
+    inventoryNo: newInventoryForm.inventoryNo || `IFS-ENV-${inventoryRecords.value.length + 1000}`,
+    factory: newInventoryForm.factory || 'Gebze',
+    department: newInventoryForm.department || 'Üretim',
+    responsible: responsible?.name || 'Belirsiz Kullanıcı',
+    responsibleRole: responsible?.role || 'Sorumlu Atanacak',
+    brand: newInventoryForm.brand || 'Dell',
+    model: newInventoryForm.model || 'Latitude 7440',
+    state: 'available',
+    detailRoute: { name: 'stock-tracking', query: { ref: newInventoryForm.inventoryNo || 'IFS-ENV' } }
+  };
+
+  inventoryRecords.value = [newRecord, ...inventoryRecords.value];
+  closeAddInventoryModal();
+  router.push({ name: 'stock-tracking', query: { source: 'inventory' } });
+};
+
+const showFaultyRecords = () => {
+  selectedSegment.value = 'faulty';
+  filtersOpen.value = false;
+};
+
+const handleActionChange = (record: InventoryRecord, action: string) => {
+  selectedActions[record.id] = action;
+
+  switch (action) {
+    case 'detail':
+      router.push(record.detailRoute);
+      break;
+    case 'handover':
+      router.push({ name: 'request-tracking' });
+      break;
+    case 'faulty':
+      router.push({ name: 'scrap-management' });
+      break;
+    case 'history':
+      router.push({ name: 'records' });
+      break;
+    default:
+      break;
   }
-];
+};
 </script>
 
 <style scoped src="@/styles/workspace.css"></style>
+
+<style scoped>
+.inventory-page {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.inventory-hero {
+  background: linear-gradient(135deg, #dbeafe 0%, #eff6ff 45%, #e0f2fe 100%);
+  border-radius: 32px;
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  padding: 2.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 24px 64px rgba(59, 130, 246, 0.22);
+}
+
+.hero-copy {
+  max-width: 620px;
+  display: grid;
+  gap: 1rem;
+  color: #0f172a;
+}
+
+.hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.18);
+  color: #1d4ed8;
+  font-weight: 700;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-copy h1 {
+  margin: 0;
+  font-size: 2.4rem;
+}
+
+.hero-copy p {
+  margin: 0;
+  line-height: 1.65;
+  color: rgba(15, 23, 42, 0.78);
+}
+
+.hero-links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.16);
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.hero-links a:hover {
+  background: rgba(37, 99, 235, 0.24);
+}
+
+.hero-metrics {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin: 0;
+}
+
+.hero-metrics dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: rgba(30, 64, 175, 0.86);
+  margin-bottom: 0.35rem;
+}
+
+.hero-metrics dd {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #1e3a8a;
+}
+
+.metric-note {
+  margin: 0.2rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(30, 64, 175, 0.72);
+}
+
+.inventory-card {
+  background: #ffffff;
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 32px 68px rgba(15, 23, 42, 0.12);
+  padding: 2.25rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.inventory-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.inventory-card-header h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.6rem;
+}
+
+.inventory-card-header p {
+  margin: 0;
+  color: #475569;
+  max-width: 540px;
+}
+
+.inventory-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.6rem;
+  border-radius: 16px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+}
+
+.action.primary {
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #f8fafc;
+  box-shadow: 0 18px 40px rgba(37, 99, 235, 0.35);
+}
+
+.action.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 48px rgba(37, 99, 235, 0.38);
+}
+
+.action.outline {
+  background: #f8fafc;
+  border: 1px solid rgba(37, 99, 235, 0.32);
+  color: #1d4ed8;
+}
+
+.action.subtle {
+  background: rgba(148, 163, 184, 0.14);
+  color: #1e293b;
+}
+
+.inventory-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.inventory-segments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.segment-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.8);
+  color: #1e293b;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.segment-button.active {
+  background: rgba(37, 99, 235, 0.16);
+  border-color: rgba(37, 99, 235, 0.5);
+  color: #1d4ed8;
+}
+
+.segment-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.8rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.16);
+  color: #1d4ed8;
+  font-size: 0.78rem;
+}
+
+.inventory-search {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.inventory-search input {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  padding: 0.55rem 1rem;
+  min-width: 240px;
+  font-size: 0.95rem;
+}
+
+.filter-panel {
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.filter-panel header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.filter-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.filter-form label {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.filter-form select {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  padding: 0.5rem 0.75rem;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.drawer-enter-active,
+.drawer-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.drawer-enter-from,
+.drawer-leave-to {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.inventory-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.inventory-table thead {
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.inventory-table th,
+.inventory-table td {
+  padding: 0.9rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.28);
+  color: #0f172a;
+}
+
+.inventory-table th {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(71, 85, 105, 0.9);
+}
+
+.cell-title {
+  display: block;
+  font-weight: 600;
+}
+
+.cell-meta {
+  display: block;
+  margin-top: 0.2rem;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.actions-header {
+  text-align: right;
+}
+
+.actions-cell {
+  text-align: right;
+}
+
+.actions-cell select {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  padding: 0.45rem 0.75rem;
+  min-width: 170px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: #475569;
+  font-weight: 500;
+}
+
+.inventory-links {
+  background: rgba(241, 245, 249, 0.9);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  padding: 2rem;
+  display: grid;
+  gap: 1.1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 16px 38px rgba(15, 23, 42, 0.1);
+}
+
+.inventory-links h2 {
+  margin: 0;
+}
+
+.inventory-links p {
+  margin: 0;
+  color: #475569;
+}
+
+.link-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.link-grid a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 1rem;
+  border-radius: 16px;
+  text-decoration: none;
+  background: rgba(37, 99, 235, 0.14);
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.link-grid a:hover {
+  background: rgba(37, 99, 235, 0.22);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.32);
+  backdrop-filter: blur(6px);
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  z-index: 40;
+}
+
+.modal-card {
+  background: #ffffff;
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  max-width: 960px;
+  width: min(100%, 900px);
+  box-shadow: 0 36px 72px rgba(15, 23, 42, 0.22);
+  display: grid;
+  gap: 1.75rem;
+  padding: 2.25rem;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.modal-header h2 {
+  margin: 0 0 0.35rem;
+}
+
+.modal-header p {
+  margin: 0;
+  color: #475569;
+}
+
+.modal-close {
+  background: rgba(148, 163, 184, 0.16);
+  border: none;
+  border-radius: 999px;
+  width: 2.25rem;
+  height: 2.25rem;
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #1e293b;
+}
+
+.modal-form {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.modal-grid {
+  display: grid;
+  gap: 1.25rem 1.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.form-field {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.form-field span {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.form-field small {
+  font-weight: 500;
+  color: #64748b;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  padding: 0.65rem 1rem;
+  font-size: 0.95rem;
+  color: #0f172a;
+  background: rgba(248, 250, 252, 0.85);
+}
+
+.form-field textarea {
+  resize: vertical;
+}
+
+.form-field--textarea {
+  grid-column: 1 / -1;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.85rem;
+}
+
+.backdrop-enter-active,
+.backdrop-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.backdrop-enter-from,
+.backdrop-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+}
+
+@media (max-width: 768px) {
+  .inventory-card {
+    padding: 1.75rem;
+  }
+
+  .inventory-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .inventory-search {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .inventory-search input {
+    flex: 1;
+  }
+
+  .inventory-table {
+    min-width: unset;
+  }
+
+  .modal-card {
+    padding: 1.75rem;
+    border-radius: 22px;
+  }
+
+  .modal-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/views/LicenseTrackingView.vue
+++ b/frontend/src/views/LicenseTrackingView.vue
@@ -1,217 +1,703 @@
 <template>
-  <section class="workspace-page" aria-labelledby="license-title">
-    <article class="workspace-hero">
-      <header class="hero-header">
-        <div class="hero-heading">
-          <span class="hero-badge">Yetki Merkezi</span>
-          <h1 id="license-title">Lisans Takip</h1>
-          <p class="hero-intro">
-            Kurumsal lisans envanterinizi sürüm, kullanım hakkı ve yenileme tarihine göre takip edin.
-            Envanterdeki cihazlara atanmış anahtarları görün, stoktan gelen yeni kurulum taleplerini
-            bekletmeden lisanslayın.
+  <section class="license-tracking" aria-labelledby="license-title">
+    <header class="page-hero">
+      <div class="hero-text">
+        <p class="hero-eyebrow">Yetki Merkezi</p>
+        <h1 id="license-title">Lisans Takip</h1>
+        <p class="hero-subtitle">
+          Yazılım lisanslarını görüntüleyin ve yönetin. Anahtarların atama durumlarını, sorumlu ekipleri ve
+          yenileme gereksinimlerini tek ekranda izleyin.
+        </p>
+        <div class="hero-links">
+          <RouterLink :to="{ name: 'inventory-tracking' }" class="hero-link">Envantere git</RouterLink>
+          <RouterLink :to="{ name: 'request-tracking' }" class="hero-link">Talep kuyruğunu aç</RouterLink>
+          <RouterLink :to="{ name: 'records' }" class="hero-link">Kayıtları incele</RouterLink>
+        </div>
+      </div>
+      <div class="hero-actions">
+        <button type="button" class="action primary" @click="createLicense">+ Yeni lisans</button>
+        <button type="button" class="action" @click="exportLicenses">Excel aktar</button>
+        <button type="button" class="action outline" @click="toggleFilters">Filtre</button>
+      </div>
+    </header>
+
+    <transition name="filter-panel">
+      <aside v-if="filtersOpen" class="filter-drawer" aria-label="Lisans filtreleri">
+        <header class="drawer-header">
+          <h2>Filtreler</h2>
+          <p>Durumlara göre hızlıca süzün veya anahtarları arayın.</p>
+        </header>
+        <form class="drawer-form" @submit.prevent>
+          <fieldset>
+            <legend>Durum</legend>
+            <label v-for="segment in filterSegments" :key="segment.value" class="filter-option">
+              <input
+                type="radio"
+                name="license-status"
+                :value="segment.value"
+                :checked="segment.value === selectedSegment"
+                @change="() => applySegment(segment.value)"
+              />
+              <span>{{ segment.label }} ({{ segment.count }})</span>
+            </label>
+          </fieldset>
+          <div class="filter-search">
+            <label class="sr-only" for="license-search">Lisans ara</label>
+            <input
+              id="license-search"
+              v-model="searchQuery"
+              type="search"
+              name="q"
+              placeholder="Lisans adı veya anahtar ara"
+            />
+          </div>
+          <div class="drawer-actions">
+            <button type="button" class="action" @click="resetFilters">Filtreleri sıfırla</button>
+            <button type="button" class="action outline" @click="toggleFilters">Kapat</button>
+          </div>
+        </form>
+      </aside>
+    </transition>
+
+    <article class="license-card" aria-labelledby="license-table-title">
+      <header class="card-header">
+        <div>
+          <h2 id="license-table-title">Lisanslar</h2>
+          <p>
+            Aktif, yenileme sürecinde ve atama bekleyen lisans anahtarlarını sorumlularıyla birlikte görüntüleyin.
           </p>
         </div>
-        <div class="hero-actions">
-          <RouterLink :to="{ name: 'inventory-tracking' }" class="primary-action">Zimmetleri kontrol et</RouterLink>
-          <RouterLink :to="{ name: 'request-tracking' }" class="secondary-link">Talep kuyruğunu aç</RouterLink>
-        </div>
+        <dl class="card-metrics">
+          <div v-for="metric in metrics" :key="metric.id">
+            <dt>{{ metric.label }}</dt>
+            <dd>{{ metric.value }}</dd>
+          </div>
+        </dl>
       </header>
-      <dl class="hero-metrics">
-        <div v-for="metric in heroMetrics" :key="metric.id">
-          <dt>{{ metric.label }}</dt>
-          <dd>{{ metric.value }}</dd>
-          <p class="metric-note">{{ metric.note }}</p>
-        </div>
-      </dl>
-    </article>
 
-    <div class="workspace-grid columns-2">
-      <article class="workspace-card table-card" aria-labelledby="license-overview">
-        <header>
-          <h2 id="license-overview">Aktif Lisanslar</h2>
-          <p>Ataması yapılan veya yenileme sürecinde olan lisans anahtarlarının özeti.</p>
-        </header>
+      <div class="table-wrapper">
         <table>
           <thead>
             <tr>
-              <th scope="col">Ürün</th>
-              <th scope="col">Atama</th>
-              <th scope="col">Durum</th>
-              <th scope="col">Yenileme</th>
+              <th scope="col">No</th>
+              <th scope="col">Lisans adı</th>
+              <th scope="col">Anahtar</th>
+              <th scope="col">Sorumlu</th>
+              <th scope="col">Bağlı ünvanlar</th>
+              <th scope="col">E-posta</th>
+              <th scope="col">Açıklama</th>
+              <th scope="col" class="actions-header">İşlemler</th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="license in licenseList" :key="license.key">
-              <td>
-                <span class="summary-title">{{ license.product }}</span>
-                <p class="summary-meta">Anahtar: {{ license.key }}</p>
+            <tr v-for="(record, index) in filteredRecords" :key="record.id">
+              <td data-title="No">{{ index + 1 }}</td>
+              <td data-title="Lisans adı">
+                <span class="cell-title">{{ record.name }}</span>
+                <span class="status-tag" :class="`status-${record.status}`">{{ statusLabels[record.status] }}</span>
               </td>
-              <td>{{ license.assignedTo }}</td>
-              <td>
-                <span class="status-chip">{{ statusLabels[license.status] }}</span>
+              <td data-title="Anahtar">
+                <code class="license-key">{{ record.key }}</code>
               </td>
-              <td>{{ license.renewal }}</td>
+              <td data-title="Sorumlu">
+                <span class="cell-title">{{ record.owner }}</span>
+                <span class="cell-meta">{{ record.ownerRole }}</span>
+              </td>
+              <td data-title="Bağlı ünvanlar">{{ record.linkedUnits }}</td>
+              <td data-title="E-posta">{{ record.email }}</td>
+              <td data-title="Açıklama">
+                <span v-if="record.note" class="note">{{ record.note }}</span>
+                <span v-else class="note muted">-</span>
+              </td>
+              <td data-title="İşlemler" class="actions-cell">
+                <label class="sr-only" :for="`action-${record.id}`">{{ record.name }} işlemleri</label>
+                <select
+                  :id="`action-${record.id}`"
+                  :value="selectedActions[record.id] ?? ''"
+                  @change="(event) => handleActionChange(record, (event.target as HTMLSelectElement).value)"
+                >
+                  <option value="" disabled>Seçiniz...</option>
+                  <option value="detail">Detaya git</option>
+                  <option value="assign">Envantere yönlendir</option>
+                  <option value="request">Talep oluştur</option>
+                  <option value="cancel">Lisansı iptal et</option>
+                </select>
+              </td>
             </tr>
           </tbody>
         </table>
-      </article>
-
-      <article class="workspace-card" aria-labelledby="license-actions">
-        <header>
-          <h2 id="license-actions">Modüller Arası Akış</h2>
-          <p>Talep, stok ve envanter süreçleriyle lisans atamalarını senkronize edin.</p>
-        </header>
-        <div class="quick-actions">
-          <RouterLink v-for="link in relatedLinks" :key="link.title" :to="link.to">
-            {{ link.title }} <span aria-hidden="true">→</span>
-          </RouterLink>
-        </div>
-        <footer>
-          <RouterLink :to="{ name: 'knowledge-base' }" class="card-link">Lisans politikalarını aç</RouterLink>
-        </footer>
-      </article>
-
-      <article class="workspace-card" aria-labelledby="license-log">
-        <header>
-          <h2 id="license-log">Lisans Hareketleri</h2>
-          <p>Yenileme ve atama değişikliklerinin kronolojisi.</p>
-        </header>
-        <ul class="timeline">
-          <li v-for="entry in movementLog" :key="entry.id" class="timeline-entry">
-            <span class="timeline-dot" aria-hidden="true"></span>
-            <div class="timeline-content">
-              <p class="timeline-title">{{ entry.text }}</p>
-              <p class="timeline-meta">{{ entry.time }}</p>
-              <RouterLink v-if="entry.relatedRoute" :to="entry.relatedRoute" class="timeline-link">
-                Kayda git
-              </RouterLink>
-            </div>
-          </li>
-        </ul>
-      </article>
-    </div>
-
-    <article class="workflow-card">
-      <h2>Lisans Döngüsü</h2>
-      <ol class="workflow-steps">
-        <li>
-          Talep modülünden gelen yazılım isteği onaylandığında stokta ilgili kurulum planlanır ve
-          lisans anahtarı rezerve edilir.
-        </li>
-        <li>
-          Kurulum tamamlandığında anahtar envanter kartına bağlanır ve sorumlu ekip bilgilendirilir.
-        </li>
-        <li>
-          Yenileme tarihleri <RouterLink :to="{ name: 'records' }">Kayıtlar</RouterLink> ve
-          <RouterLink :to="{ name: 'profile' }">Profil</RouterLink> bildirimleriyle takip edilir.
-        </li>
-      </ol>
+      </div>
     </article>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
-import { RouterLink, type RouteLocationRaw } from 'vue-router';
+import { computed, reactive, ref } from 'vue';
+import { RouterLink, useRouter } from 'vue-router';
 
-const statusLabels = {
-  active: 'Aktif',
-  warning: 'Yenileme Yaklaşıyor',
-  available: 'Atama Bekliyor'
-} as const;
+interface LicenseRecord {
+  id: number;
+  name: string;
+  key: string;
+  owner: string;
+  ownerRole: string;
+  linkedUnits: string;
+  email: string;
+  status: 'active' | 'expiring' | 'awaiting';
+  note?: string;
+}
 
-type LicenseStatus = keyof typeof statusLabels;
-
-interface HeroMetric {
+interface MetricItem {
   id: string;
   label: string;
   value: string;
-  note: string;
 }
 
-interface LicenseRow {
-  key: string;
-  product: string;
-  assignedTo: string;
-  status: LicenseStatus;
-  renewal: string;
+interface FilterSegment {
+  value: FilterValue;
+  label: string;
+  count: number;
 }
 
-interface RelatedLink {
-  title: string;
-  to: RouteLocationRaw;
-}
+type FilterValue = 'all' | 'active' | 'expiring' | 'awaiting';
 
-interface MovementLogEntry {
-  id: number;
-  time: string;
-  text: string;
-  relatedRoute?: RouteLocationRaw;
-}
+const router = useRouter();
 
-const licenseList: LicenseRow[] = [
-  {
-    key: 'MSFT-O365-84J2',
-    product: 'Microsoft 365 E3',
-    assignedTo: 'Finans / NB-1042',
-    status: 'active',
-    renewal: '30 gün kaldı'
-  },
-  {
-    key: 'ADBE-CC-10S9',
-    product: 'Adobe Creative Cloud',
-    assignedTo: 'Tasarım / NB-2088',
-    status: 'warning',
-    renewal: '7 gün kaldı'
-  },
-  {
-    key: 'JETB-INT-660P',
-    product: 'JetBrains IntelliJ IDEA',
-    assignedTo: 'Ar-Ge / NB-3001',
-    status: 'available',
-    renewal: 'Atama bekliyor'
-  }
-];
-
-const heroMetrics = computed<HeroMetric[]>(() => {
-  const active = licenseList.filter((license) => license.status === 'active').length;
-  const warning = licenseList.filter((license) => license.status === 'warning').length;
-  const available = licenseList.filter((license) => license.status === 'available').length;
-
-  return [
-    { id: 'total', label: 'Toplam Lisans', value: String(licenseList.length), note: 'Takip edilen ürün' },
-    { id: 'active', label: 'Aktif', value: String(active), note: 'Kullanımda olan lisans' },
-    { id: 'warning', label: 'Yenileme Uyarısı', value: String(warning), note: 'Yaklaşan yenileme' },
-    { id: 'available', label: 'Bekleyen Atama', value: String(available), note: 'Rezerve anahtar' }
-  ];
-});
-
-const relatedLinks: RelatedLink[] = [
-  { title: 'Stok Takip', to: { name: 'stock-tracking' } },
-  { title: 'Envanter Takip', to: { name: 'inventory-tracking' } },
-  { title: 'Talep Takip', to: { name: 'request-tracking' } }
-];
-
-const movementLog: MovementLogEntry[] = [
+const licenseRecords = ref<LicenseRecord[]>([
   {
     id: 1,
-    time: 'Bugün 11:03',
-    text: 'Microsoft 365 E3 lisansı NB-1042 cihazına atandı.',
-    relatedRoute: { name: 'inventory-tracking' }
+    name: 'Microsoft 365 E3',
+    key: 'MSFT-O365-84J2',
+    owner: 'Sistem Yöneticisi',
+    ownerRole: 'Bulut Ekibi',
+    linkedUnits: 'Finans, Operasyon',
+    email: 'sistem@acme.com',
+    status: 'active'
   },
   {
     id: 2,
-    time: 'Bugün 08:45',
-    text: 'Adobe Creative Cloud lisansı için yenileme uyarısı oluşturuldu.',
-    relatedRoute: { name: 'records' }
+    name: 'Adobe Creative Cloud',
+    key: 'ADBE-CC-10S9',
+    owner: 'Tasarım Koordinatörü',
+    ownerRole: 'Tasarım Ekibi',
+    linkedUnits: 'Tasarım, Pazarlama',
+    email: 'design@acme.com',
+    status: 'expiring',
+    note: '7 gün içinde yenileme gerekiyor.'
   },
   {
     id: 3,
-    time: 'Dün 17:20',
-    text: 'JetBrains IntelliJ IDEA lisansı stokta boşta beklemeye alındı.',
-    relatedRoute: { name: 'stock-tracking' }
+    name: 'JetBrains IntelliJ IDEA',
+    key: 'JETB-INT-660P',
+    owner: 'Ar-Ge Lideri',
+    ownerRole: 'Yazılım Ekibi',
+    linkedUnits: 'Ar-Ge',
+    email: 'rge@acme.com',
+    status: 'awaiting',
+    note: 'Yeni cihaz ataması bekliyor.'
+  },
+  {
+    id: 4,
+    name: 'Autodesk AutoCAD',
+    key: 'AUTO-CAD-332T',
+    owner: 'Proje Müdürü',
+    ownerRole: 'Mimari Tasarım',
+    linkedUnits: 'Mimari, Saha',
+    email: 'proje@acme.com',
+    status: 'active'
   }
-];
+]);
+
+const statusLabels = {
+  active: 'Aktif',
+  expiring: 'Yenileme Yakın',
+  awaiting: 'Atama Bekliyor'
+} as const;
+
+const selectedActions = reactive<Record<number, string>>({});
+const filtersOpen = ref(false);
+const selectedSegment = ref<FilterValue>('all');
+const searchQuery = ref('');
+
+const metrics = computed<MetricItem[]>(() => {
+  const total = licenseRecords.value.length;
+  const active = licenseRecords.value.filter((record) => record.status === 'active').length;
+  const expiring = licenseRecords.value.filter((record) => record.status === 'expiring').length;
+  const awaiting = licenseRecords.value.filter((record) => record.status === 'awaiting').length;
+
+  return [
+    { id: 'total', label: 'Toplam', value: String(total) },
+    { id: 'active', label: 'Aktif', value: String(active) },
+    { id: 'expiring', label: 'Yenileme', value: String(expiring) },
+    { id: 'awaiting', label: 'Bekleyen', value: String(awaiting) }
+  ];
+});
+
+const filterSegments = computed<FilterSegment[]>(() => {
+  const counts: Record<FilterValue, number> = {
+    all: licenseRecords.value.length,
+    active: licenseRecords.value.filter((record) => record.status === 'active').length,
+    expiring: licenseRecords.value.filter((record) => record.status === 'expiring').length,
+    awaiting: licenseRecords.value.filter((record) => record.status === 'awaiting').length
+  };
+
+  return [
+    { value: 'all', label: 'Tüm lisanslar', count: counts.all },
+    { value: 'active', label: 'Aktif kullanım', count: counts.active },
+    { value: 'expiring', label: 'Yenileme uyarısı', count: counts.expiring },
+    { value: 'awaiting', label: 'Atama bekleyen', count: counts.awaiting }
+  ];
+});
+
+const filteredRecords = computed(() => {
+  const normalizedQuery = searchQuery.value.trim().toLowerCase();
+
+  return licenseRecords.value.filter((record) => {
+    const segmentMatch =
+      selectedSegment.value === 'all' || record.status === selectedSegment.value;
+
+    const queryMatch =
+      !normalizedQuery ||
+      record.name.toLowerCase().includes(normalizedQuery) ||
+      record.key.toLowerCase().includes(normalizedQuery) ||
+      record.owner.toLowerCase().includes(normalizedQuery);
+
+    return segmentMatch && queryMatch;
+  });
+});
+
+const toggleFilters = () => {
+  filtersOpen.value = !filtersOpen.value;
+};
+
+const applySegment = (value: FilterValue) => {
+  selectedSegment.value = value;
+};
+
+const resetFilters = () => {
+  selectedSegment.value = 'all';
+  searchQuery.value = '';
+};
+
+const createLicense = () => {
+  window.alert('Yeni lisans oluşturma akışı yakında burada olacak.');
+};
+
+const exportLicenses = () => {
+  window.alert('Lisans listesi excel çıktısı olarak dışa aktarılıyor.');
+};
+
+const askForCancellationReason = (record: LicenseRecord) => {
+  const reason = window.prompt('Lisans iptal sebebini giriniz:', record.note ?? '');
+  if (!reason) {
+    return;
+  }
+
+  record.status = 'awaiting';
+  record.note = `İptal edildi: ${reason}`;
+};
+
+const handleActionChange = (record: LicenseRecord, value: string) => {
+  if (!value) {
+    return;
+  }
+
+  switch (value) {
+    case 'detail':
+      router.push({ name: 'records', query: { license: record.key } });
+      break;
+    case 'assign':
+      router.push({ name: 'inventory-tracking', query: { focus: record.key } });
+      break;
+    case 'request':
+      router.push({ name: 'request-tracking', query: { license: record.key } });
+      break;
+    case 'cancel':
+      askForCancellationReason(record);
+      break;
+    default:
+      break;
+  }
+
+  selectedActions[record.id] = '';
+};
 </script>
 
-<style scoped src="@/styles/workspace.css"></style>
+<style scoped>
+.license-tracking {
+  display: grid;
+  gap: 2rem;
+  color: #0f172a;
+}
+
+.page-hero {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(59, 130, 246, 0.05));
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 28px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 70px rgba(59, 130, 246, 0.18);
+}
+
+.hero-text {
+  max-width: 620px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero-eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #2563eb;
+  font-weight: 700;
+}
+
+.hero-text h1 {
+  margin: 0;
+  font-size: 2.25rem;
+}
+
+.hero-subtitle {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #475569;
+}
+
+.hero-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.hero-link {
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.hero-link:hover {
+  text-decoration: underline;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.action {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  background: rgba(255, 255, 255, 0.75);
+  color: #1e3a8a;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 12px 28px rgba(148, 163, 184, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.action.primary {
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #f8fafc;
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.35);
+}
+
+.action.outline {
+  background: transparent;
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  color: #1d4ed8;
+}
+
+.action:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(148, 163, 184, 0.35);
+}
+
+.filter-panel-enter-active,
+.filter-panel-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.filter-panel-enter-from,
+.filter-panel-leave-to {
+  opacity: 0;
+}
+
+.filter-drawer {
+  background: rgba(248, 250, 252, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 24px;
+  padding: 1.75rem;
+  display: grid;
+  gap: 1.5rem;
+  box-shadow: 0 20px 48px rgba(15, 23, 42, 0.18);
+}
+
+.drawer-header h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.35rem;
+}
+
+.drawer-header p {
+  margin: 0;
+  color: #475569;
+}
+
+.drawer-form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.filter-option {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  color: #1e293b;
+}
+
+.filter-search input {
+  width: 100%;
+  padding: 0.65rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: #ffffff;
+  font-size: 0.95rem;
+}
+
+.drawer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.license-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 2rem;
+  display: grid;
+  gap: 1.75rem;
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.12);
+}
+
+.card-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.75rem;
+  align-items: flex-start;
+}
+
+.card-header h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+}
+
+.card-header p {
+  margin: 0;
+  color: #475569;
+}
+
+.card-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.card-metrics div {
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  text-align: center;
+}
+
+.card-metrics dt {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #1e3a8a;
+}
+
+.card-metrics dd {
+  margin: 0.35rem 0 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+th,
+td {
+  padding: 0.9rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+th {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: #475569;
+}
+
+tbody tr:hover {
+  background: rgba(226, 232, 240, 0.35);
+}
+
+.cell-title {
+  display: block;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.cell-meta {
+  display: block;
+  color: #475569;
+  font-size: 0.85rem;
+}
+
+.license-key {
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 8px;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.9rem;
+  color: #1d4ed8;
+}
+
+.status-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  margin-top: 0.45rem;
+}
+
+.status-active {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.status-expiring {
+  background: rgba(249, 115, 22, 0.18);
+  color: #c2410c;
+}
+
+.status-awaiting {
+  background: rgba(37, 99, 235, 0.14);
+  color: #1d4ed8;
+}
+
+.note {
+  display: block;
+  max-width: 220px;
+  line-height: 1.45;
+}
+
+.note.muted {
+  color: #94a3b8;
+}
+
+.actions-cell select {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: #ffffff;
+  font-size: 0.9rem;
+}
+
+.actions-header {
+  min-width: 160px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 960px) {
+  .page-hero {
+    padding: 2rem;
+  }
+
+  .card-header {
+    flex-direction: column;
+  }
+
+  th,
+  td {
+    padding: 0.75rem;
+  }
+}
+
+@media (max-width: 720px) {
+  table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr {
+    display: block;
+  }
+
+  thead {
+    display: none;
+  }
+
+  tbody tr {
+    margin-bottom: 1rem;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    padding: 0.75rem;
+    background: rgba(255, 255, 255, 0.88);
+  }
+
+  td {
+    border: none;
+    padding: 0.5rem 0;
+  }
+
+  td::before {
+    content: attr(data-title);
+    display: block;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #475569;
+    margin-bottom: 0.35rem;
+  }
+
+  .actions-cell select {
+    width: 100%;
+  }
+}
+</style>

--- a/frontend/src/views/RequestTrackingView.vue
+++ b/frontend/src/views/RequestTrackingView.vue
@@ -1,280 +1,1055 @@
 <template>
-  <section class="workspace-page" aria-labelledby="request-title">
-    <article class="workspace-hero">
-      <header class="hero-header">
-        <div class="hero-heading">
-          <span class="hero-badge">Operasyon Merkezi</span>
-          <h1 id="request-title">Talep Takip</h1>
-          <p class="hero-intro">
-            Envanter, lisans ve destek ihtiyaçları için açılan talepleri uçtan uca yönetin. Durumlara
-            göre iş akışlarını takip ederek onaylanan ürünleri envantere aktarın, iptal edilenleri ise
-            kayıt altına alarak süreci şeffaflaştırın.
-          </p>
-        </div>
-        <div class="hero-actions">
-          <RouterLink :to="{ name: 'stock-tracking' }" class="primary-action">Stok rezervasyonlarını aç</RouterLink>
-          <RouterLink :to="{ name: 'records' }" class="secondary-link">Denetim kayıtlarını incele</RouterLink>
+  <section class="request-page" aria-labelledby="request-page-title">
+    <header class="page-header">
+      <div class="header-copy">
+        <span class="page-badge">Talep</span>
+        <h1 id="request-page-title">Talepler</h1>
+        <p>
+          Açık talepleri, tamamlanan teslimatları ve iptal edilen kayıtları bu panelden yönetin. Her durum
+          için filtreleyerek ilgili modüllere hızlıca geçiş yapabilirsiniz.
+        </p>
+      </div>
+      <div class="header-actions">
+        <button type="button" class="ghost-button" @click="downloadExcel">
+          <span aria-hidden="true">⬇️</span>
+          Excel
+        </button>
+        <button type="button" class="primary-button" @click="openRequestForm">
+          Talep Aç
+        </button>
+      </div>
+    </header>
+
+    <article class="table-card" aria-labelledby="request-table-title">
+      <header class="table-card-header">
+        <nav class="status-tabs" aria-label="Talep durum filtreleri">
+          <button
+            v-for="tab in statusTabs"
+            :key="tab.id"
+            type="button"
+            class="tab-button"
+            :class="{ active: selectedStatus === tab.id }"
+            @click="selectedStatus = tab.id"
+          >
+            <span>{{ tab.label }}</span>
+            <span class="tab-count" aria-hidden="true">{{ tab.count }}</span>
+          </button>
+        </nav>
+        <div class="tab-copy">
+          <h2 id="request-table-title">{{ activeTab.title }}</h2>
+          <p>{{ activeTab.description }}</p>
         </div>
       </header>
-      <dl class="hero-metrics">
-        <div v-for="metric in heroMetrics" :key="metric.id">
-          <dt>{{ metric.label }}</dt>
-          <dd>{{ metric.value }}</dd>
-          <p class="metric-note">{{ metric.note }}</p>
-        </div>
-      </dl>
-    </article>
 
-    <div class="workspace-grid columns-2 request-grid">
-      <article
-        v-for="column in requestColumns"
-        :key="column.id"
-        class="workspace-card status-card"
-        :style="{ '--status-accent': column.accent }"
-      >
-        <header class="status-header">
-          <div>
-            <h2>{{ column.title }}</h2>
-            <p>{{ column.description }}</p>
-          </div>
-          <span class="status-counter">{{ column.items.length }}</span>
-        </header>
-        <ul class="status-list">
-          <li v-for="item in column.items" :key="item.id">
-            <p class="status-title">{{ item.title }}</p>
-            <p class="status-meta">
-              <span>{{ item.requester }}</span>
-              <span aria-hidden="true">•</span>
-              <span>{{ item.product }}</span>
-            </p>
-            <p class="status-note">{{ item.statusNote }}</p>
-            <div class="status-actions">
-              <span class="status-tag">{{ item.updatedAt }}</span>
-              <RouterLink :to="{ name: item.targetRoute }" class="card-link">
-                {{ item.targetLabel }}
-              </RouterLink>
-            </div>
-          </li>
-        </ul>
-        <footer>
-          <RouterLink :to="{ name: column.footerRoute }" class="footer-link">
-            {{ column.footerLabel }}
-          </RouterLink>
-          <p class="summary-note">{{ column.footerNote }}</p>
-        </footer>
-      </article>
-
-      <article class="workspace-card wide" aria-labelledby="followups-title">
-        <header>
-          <h2 id="followups-title">İlgili İşlemler</h2>
-          <p>Talep akışını destekleyen modüllere hızlı geçiş yapın.</p>
-        </header>
-        <div class="quick-actions">
-          <RouterLink :to="{ name: 'inventory-tracking' }">
-            Teslim edilen ürünleri kaydet <span aria-hidden="true">→</span>
-          </RouterLink>
-          <RouterLink :to="{ name: 'scrap-management' }">
-            Hurda değerlendirmelerini gözden geçir <span aria-hidden="true">→</span>
-          </RouterLink>
-          <RouterLink :to="{ name: 'knowledge-base' }">
-            Talep onay rehberini aç <span aria-hidden="true">→</span>
-          </RouterLink>
-        </div>
-      </article>
-    </div>
-
-    <article class="workflow-card">
-      <h2>Operasyon Akışı</h2>
-      <ol class="workflow-steps">
-        <li>
-          Talep açılır ve durum <strong>Bekleyen</strong> olarak kaydedilir. İlgili stoklar için
-          <RouterLink :to="{ name: 'stock-tracking' }">Stok Takip</RouterLink> modülünden rezervasyon
-          yapılır.
-        </li>
-        <li>
-          Ürün teslim edildiğinde statü <strong>Karşılandı</strong> olur ve
-          <RouterLink :to="{ name: 'inventory-tracking' }">Envanter Takip</RouterLink> modülüne
-          otomatik giriş yapılır.
-        </li>
-        <li>
-          Reddedilen veya iptal edilen talepler <strong>İptal</strong> kolonuna taşınır ve
-          <RouterLink :to="{ name: 'records' }">Kayıtlar</RouterLink> bölümünde loglanır.
-        </li>
-      </ol>
-      <div class="chip-group">
-        <RouterLink :to="{ name: 'admin-panel' }" class="primary-action">Onay kurallarını düzenle</RouterLink>
-        <RouterLink :to="{ name: 'profile' }" class="secondary-link">Onaycı listeni kontrol et</RouterLink>
+      <div class="table-wrapper" role="region" :aria-label="activeTab.title">
+        <table class="request-table">
+          <thead>
+            <tr>
+              <th scope="col">IFS No</th>
+              <th scope="col">Donanım Tipi</th>
+              <th scope="col">Marka</th>
+              <th scope="col">Model</th>
+              <th scope="col">Miktar</th>
+              <th scope="col">Tarih</th>
+              <th scope="col">Açıklama</th>
+              <th scope="col" class="table-actions">İşlemler</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="request in filteredRequests" :key="request.id">
+              <td data-title="IFS No">{{ request.ifsNo }}</td>
+              <td data-title="Donanım Tipi">{{ request.hardwareType }}</td>
+              <td data-title="Marka">{{ request.brand }}</td>
+              <td data-title="Model">{{ request.model }}</td>
+              <td data-title="Miktar">{{ request.quantity }}</td>
+              <td data-title="Tarih">{{ request.date }}</td>
+              <td data-title="Açıklama">{{ request.note }}</td>
+              <td data-title="İşlemler" class="table-actions">
+                <div class="action-group">
+                  <button
+                    type="button"
+                    class="action-button stock"
+                    :title="request.targetLabel"
+                    @click="handleStockEntry(request)"
+                  >
+                    Stok Gir
+                  </button>
+                  <button
+                    type="button"
+                    class="action-button cancel"
+                    @click="cancelRequest(request)"
+                  >
+                    İptal Et
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr v-if="filteredRequests.length === 0">
+              <td colspan="8" class="empty-state">{{ activeTab.emptyMessage }}</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </article>
+    <transition name="modal-fade">
+      <div
+        v-if="isRequestFormOpen"
+        class="modal-backdrop"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="request-modal-title"
+        @click.self="closeRequestForm"
+      >
+        <form class="modal-dialog" @submit.prevent="submitRequestForm">
+          <header class="modal-header">
+            <div class="modal-title-group">
+              <h2 id="request-modal-title">Talep Aç</h2>
+              <p>IFS numarası isteğe bağlıdır. Satır ekleyerek talep detayını oluşturun.</p>
+            </div>
+            <button type="button" class="icon-button" @click="closeRequestForm">
+              <span aria-hidden="true">×</span>
+              <span class="sr-only">Talep formunu kapat</span>
+            </button>
+          </header>
+
+          <div class="modal-body">
+            <label class="field-label" for="request-ifs-input">
+              IFS No <span class="optional">(opsiyonel)</span>
+            </label>
+            <input
+              id="request-ifs-input"
+              v-model.trim="requestForm.ifsNo"
+              type="text"
+              class="text-input"
+              placeholder="IFS-0001"
+              autocomplete="off"
+            />
+
+            <div class="line-items-toolbar">
+              <h3>Kalemler</h3>
+              <button type="button" class="link-button" @click="addLineItem">Satır Ekle</button>
+            </div>
+
+            <div class="line-items-grid" role="group" aria-label="Talep kalemleri">
+              <div class="line-items-head" aria-hidden="true">
+                <span>Donanım Tipi</span>
+                <span>Miktar</span>
+                <span>Marka</span>
+                <span>Model</span>
+                <span>Açıklama</span>
+              </div>
+              <div v-for="item in requestForm.items" :key="item.uid" class="line-items-row">
+                <select v-model="item.hardwareType" class="select-input">
+                  <option value="">Seçiniz...</option>
+                  <option v-for="option in hardwareTypeOptions" :key="option" :value="option">
+                    {{ option }}
+                  </option>
+                </select>
+                <input
+                  v-model.trim="item.quantity"
+                  type="text"
+                  class="text-input"
+                  placeholder="1 Adet"
+                  inputmode="decimal"
+                />
+                <input
+                  v-model.trim="item.brand"
+                  type="text"
+                  class="text-input"
+                  placeholder="Marka"
+                  autocomplete="off"
+                />
+                <input
+                  v-model.trim="item.model"
+                  type="text"
+                  class="text-input"
+                  placeholder="Model"
+                  autocomplete="off"
+                />
+                <input
+                  v-model.trim="item.note"
+                  type="text"
+                  class="text-input"
+                  placeholder="Açıklama"
+                  autocomplete="off"
+                />
+              </div>
+            </div>
+          </div>
+
+          <footer class="modal-footer">
+            <button type="button" class="ghost-button" @click="closeRequestForm">Vazgeç</button>
+            <button type="submit" class="primary-button">Gönder</button>
+          </footer>
+        </form>
+      </div>
+    </transition>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
-import { RouterLink } from 'vue-router';
+import { computed, reactive, ref } from 'vue';
+import { useRouter } from 'vue-router';
 
-type RequestStatus = 'pending' | 'delivered' | 'cancelled';
+type RequestStatus = 'open' | 'completed' | 'cancelled';
 
 type RouteName =
-  | 'stock-tracking'
-  | 'license-tracking'
+  | 'home'
   | 'inventory-tracking'
+  | 'license-tracking'
   | 'printer-tracking'
-  | 'records'
-  | 'scrap-management'
-  | 'admin-panel'
+  | 'stock-tracking'
+  | 'request-tracking'
   | 'knowledge-base'
-  | 'profile';
+  | 'scrap-management'
+  | 'profile'
+  | 'admin-panel'
+  | 'records';
 
-interface HeroMetric {
+interface RequestRecord {
   id: string;
+  ifsNo: string;
+  status: RequestStatus;
+  hardwareType: string;
+  brand: string;
+  model: string;
+  quantity: string;
+  date: string;
+  note: string;
+  targetRoute: RouteName;
+  targetLabel: string;
+  cancellationReason?: string;
+}
+
+interface StatusCopy {
+  id: RequestStatus;
   label: string;
-  value: string;
+  title: string;
+  description: string;
+  emptyMessage: string;
+}
+
+interface RequestFormItem {
+  uid: number;
+  hardwareType: string;
+  quantity: string;
+  brand: string;
+  model: string;
   note: string;
 }
 
-interface RequestItem {
-  id: string;
-  title: string;
-  requester: string;
-  product: string;
-  status: RequestStatus;
-  updatedAt: string;
-  statusNote: string;
-  targetRoute: RouteName;
-  targetLabel: string;
-}
+const router = useRouter();
 
-interface BaseColumn {
-  id: RequestStatus;
-  title: string;
-  description: string;
-  accent: string;
-  footerLabel: string;
-  footerRoute: RouteName;
-  footerNote: string;
-}
-
-const requests: RequestItem[] = [
+const requests = ref<RequestRecord[]>([
   {
     id: 'RQ-1045',
-    title: 'Yeni dizüstü bilgisayar talebi',
-    requester: 'Ayşe Yılmaz',
-    product: 'Dell Latitude 5440',
-    status: 'pending',
-    updatedAt: '11.03.2024',
-    statusNote: 'Tedarik biriminden stok teyidi bekleniyor.',
+    ifsNo: 'IFS-2024-045',
+    status: 'open',
+    hardwareType: 'Dizüstü Bilgisayar',
+    brand: 'Dell',
+    model: 'Latitude 5440',
+    quantity: '1 Adet',
+    date: '11.03.2024',
+    note: 'Yeni çalışan için cihaz bekleniyor.',
     targetRoute: 'stock-tracking',
-    targetLabel: 'Stok kontrolüne git'
+    targetLabel: 'Stok kartına git'
   },
   {
     id: 'RQ-1046',
-    title: 'Adobe lisans yenilemesi',
-    requester: 'Kerem Durmaz',
-    product: 'Adobe Creative Cloud',
-    status: 'pending',
-    updatedAt: '12.03.2024',
-    statusNote: 'Finans onayı son aşamada.',
+    ifsNo: 'IFS-2024-046',
+    status: 'open',
+    hardwareType: 'Yazılım Lisansı',
+    brand: 'Adobe',
+    model: 'Creative Cloud',
+    quantity: '5 Kullanıcı',
+    date: '12.03.2024',
+    note: 'Finans onayı sürecinde olan lisans yenilemesi.',
     targetRoute: 'license-tracking',
-    targetLabel: 'Lisans kaydını aç'
+    targetLabel: 'Lisans kaydına git'
   },
   {
     id: 'RQ-1041',
-    title: 'Çağrı merkezi kulaklığı değişimi',
-    requester: 'Elif Ak',
-    product: 'Jabra Evolve 65',
-    status: 'delivered',
-    updatedAt: '08.03.2024',
-    statusNote: 'Teslim edildi, envanterde kayıt oluşturuldu.',
+    ifsNo: 'IFS-2024-041',
+    status: 'completed',
+    hardwareType: 'Kulaklık',
+    brand: 'Jabra',
+    model: 'Evolve 65',
+    quantity: '12 Adet',
+    date: '08.03.2024',
+    note: 'Teslim edildi ve envanter güncellendi.',
     targetRoute: 'inventory-tracking',
-    targetLabel: 'Envanter kartını gör'
+    targetLabel: 'Envanter kaydına git'
   },
   {
     id: 'RQ-1033',
-    title: 'Yazıcı toner siparişi',
-    requester: 'Operasyon Ekibi',
-    product: 'HP 410X Toner Seti',
-    status: 'delivered',
-    updatedAt: '06.03.2024',
-    statusNote: 'Teslim edildi, yazıcı stokları güncellendi.',
+    ifsNo: 'IFS-2024-033',
+    status: 'completed',
+    hardwareType: 'Toner',
+    brand: 'HP',
+    model: '410X',
+    quantity: '6 Kutu',
+    date: '06.03.2024',
+    note: 'Teslimat sonrası yazıcı stoğu yenilendi.',
     targetRoute: 'printer-tracking',
-    targetLabel: 'Yazıcı kaydını aç'
+    targetLabel: 'Yazıcı kaydına git'
   },
   {
     id: 'RQ-1027',
-    title: 'ERP erişim talebi',
-    requester: 'Mert Çelik',
-    product: 'SAP Kullanıcı Yetkisi',
+    ifsNo: 'IFS-2024-027',
     status: 'cancelled',
-    updatedAt: '04.03.2024',
-    statusNote: 'Talep sahibi tarafından iptal edildi.',
+    hardwareType: 'Erişim Yetkisi',
+    brand: 'SAP',
+    model: 'Kullanıcı Yetkisi',
+    quantity: '1 Talep',
+    date: '04.03.2024',
+    note: 'Talep sahibi tarafından iptal edildi. / İptal sebebi: Yetki ihtiyacı ortadan kalktı.',
     targetRoute: 'records',
-    targetLabel: 'Log kaydını görüntüle'
+    targetLabel: 'İşlem kaydına git',
+    cancellationReason: 'Yetki ihtiyacı ortadan kalktı.'
   },
   {
     id: 'RQ-1019',
-    title: 'Arızalı yazıcı hurdaya çıkarma',
-    requester: 'Destek Ekibi',
-    product: 'Canon iR-ADV DX 4745i',
+    ifsNo: 'IFS-2024-019',
     status: 'cancelled',
-    updatedAt: '01.03.2024',
-    statusNote: 'Hurda komitesi kararı bekleniyor, kayıtlar güncellendi.',
+    hardwareType: 'Ofis Ekipmanı',
+    brand: 'Canon',
+    model: 'iR-ADV DX 4745i',
+    quantity: '1 Ünite',
+    date: '01.03.2024',
+    note: 'Hurda komitesi kararı bekleniyor.',
     targetRoute: 'scrap-management',
-    targetLabel: 'Hurda listesini kontrol et'
+    targetLabel: 'Hurda listesine git'
   }
-];
+]);
 
-const baseColumns: BaseColumn[] = [
+const statusCopies: StatusCopy[] = [
   {
-    id: 'pending',
-    title: 'Bekleyen Talepler',
-    description: 'Onay ve stok kontrolü sürecindeki talepler.',
-    accent: '#f59e0b',
-    footerLabel: 'Stok ve finans kontrollerine git',
-    footerRoute: 'stock-tracking',
-    footerNote: 'Taleplerin karşılanması için stok rezervasyonlarını yönetin.'
+    id: 'open',
+    label: 'Açık',
+    title: 'Açık Talepler',
+    description: 'Onay ve tedarik bekleyen taleplerin detayları.',
+    emptyMessage: 'Açık talep bulunamadı.'
   },
   {
-    id: 'delivered',
-    title: 'Karşılanan Talepler',
-    description: 'Teslimi yapılan ve envantere işlenen talepler.',
-    accent: '#22c55e',
-    footerLabel: 'Envanter kayıtlarını görüntüle',
-    footerRoute: 'inventory-tracking',
-    footerNote: 'Teslim edilen ürünlerin envanter kartlarını inceleyin.'
+    id: 'completed',
+    label: 'Tamamlandı',
+    title: 'Tamamlanan Talepler',
+    description: 'Teslimatı yapılan ve envantere işlenen talepler.',
+    emptyMessage: 'Tamamlanan talep bulunamadı.'
   },
   {
     id: 'cancelled',
-    title: 'İptal / Reddedilen Talepler',
-    description: 'İptal edilen veya hurda değerlendirmesi bekleyen talepler.',
-    accent: '#ef4444',
-    footerLabel: 'Hurda listesini kontrol et',
-    footerRoute: 'scrap-management',
-    footerNote: 'İptal gerekçeleri için kayıtlar modülünü incelemeyi unutmayın.'
+    label: 'İptal',
+    title: 'İptal Edilen Talepler',
+    description: 'Talep sahibi veya yönetici tarafından iptal edilen kayıtlar.',
+    emptyMessage: 'İptal edilmiş talep bulunamadı.'
   }
 ];
 
-const requestColumns = computed(() =>
-  baseColumns.map((column) => ({
-    ...column,
-    items: requests.filter((request) => request.status === column.id)
+const selectedStatus = ref<RequestStatus>('open');
+const isRequestFormOpen = ref(false);
+
+const hardwareTypeOptions = [
+  'Dizüstü Bilgisayar',
+  'Masaüstü Bilgisayar',
+  'Monitör',
+  'Sunucu',
+  'Yazılım Lisansı',
+  'Yazıcı',
+  'Tarayıcı',
+  'Telefon',
+  'Aksesuar'
+];
+
+let formItemCounter = 0;
+const createFormItem = (): RequestFormItem => ({
+  uid: formItemCounter++,
+  hardwareType: '',
+  quantity: '',
+  brand: '',
+  model: '',
+  note: ''
+});
+
+const requestForm = reactive({
+  ifsNo: '',
+  items: [createFormItem()]
+});
+
+const statusTabs = computed(() =>
+  statusCopies.map((copy) => ({
+    ...copy,
+    count: requests.value.filter((request) => request.status === copy.id).length
   }))
 );
 
-const totalRequests = computed(() => requests.length);
+const activeTab = computed(() =>
+  statusTabs.value.find((tab) => tab.id === selectedStatus.value) ?? statusTabs.value[0]
+);
 
-const heroMetrics = computed<HeroMetric[]>(() => {
-  const pendingCount = requestColumns.value.find((column) => column.id === 'pending')?.items.length ?? 0;
-  const deliveredCount = requestColumns.value.find((column) => column.id === 'delivered')?.items.length ?? 0;
-  const cancelledCount = requestColumns.value.find((column) => column.id === 'cancelled')?.items.length ?? 0;
+const filteredRequests = computed(() =>
+  requests.value.filter((request) => request.status === selectedStatus.value)
+);
 
-  return [
-    { id: 'total', label: 'Toplam Talep', value: String(totalRequests.value), note: 'Aktif kayıt sayısı' },
-    { id: 'pending', label: 'Bekleyen', value: String(pendingCount), note: 'Onay bekleyen talep' },
-    { id: 'delivered', label: 'Karşılanan', value: String(deliveredCount), note: 'Teslim edilip envantere işlenen' },
-    { id: 'cancelled', label: 'İptal', value: String(cancelledCount), note: 'Hurda veya iptal edilen' }
-  ];
-});
+const downloadExcel = () => {
+  console.info('Talep listesi Excel formatında dışa aktarılmak üzere hazırlanıyor.');
+};
+
+const openRequestForm = () => {
+  isRequestFormOpen.value = true;
+};
+
+const handleStockEntry = (request: RequestRecord) => {
+  router.push({ name: request.targetRoute });
+};
+
+const closeRequestForm = () => {
+  isRequestFormOpen.value = false;
+  resetRequestForm();
+};
+
+const addLineItem = () => {
+  requestForm.items.push(createFormItem());
+};
+
+const resolveTargetLink = (hardwareType: string): { route: RouteName; label: string } => {
+  const normalized = hardwareType.toLowerCase();
+
+  if (normalized.includes('lisans')) {
+    return { route: 'license-tracking', label: 'Lisans kaydına git' };
+  }
+
+  if (normalized.includes('yazıcı') || normalized.includes('toner')) {
+    return { route: 'stock-tracking', label: 'Stok kaydına git' };
+  }
+
+  if (normalized.includes('erişim') || normalized.includes('yetki')) {
+    return { route: 'admin-panel', label: 'Admin paneline git' };
+  }
+
+  if (normalized.includes('sunucu')) {
+    return { route: 'inventory-tracking', label: 'Envanter kaydına git' };
+  }
+
+  return { route: 'inventory-tracking', label: 'Envanter kaydına git' };
+};
+
+const generateIfsNo = () => {
+  const now = new Date();
+  return `IFS-${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}${String(
+    now.getDate()
+  ).padStart(2, '0')}-${String(Math.floor(Math.random() * 900) + 100)}`;
+};
+
+const resetRequestForm = () => {
+  requestForm.ifsNo = '';
+  requestForm.items.splice(0, requestForm.items.length, createFormItem());
+};
+
+const submitRequestForm = () => {
+  const trimmedIfs = requestForm.ifsNo.trim();
+  const activeItems = requestForm.items.filter((item) =>
+    [item.hardwareType, item.quantity, item.brand, item.model, item.note].some((value) => value.trim() !== '')
+  );
+
+  if (activeItems.length === 0) {
+    window.alert('Gönderilecek talep satırı bulunamadı. Lütfen en az bir kalem ekleyin.');
+    return;
+  }
+
+  const hasInvalid = activeItems.some((item) => !item.hardwareType || !item.quantity.trim());
+
+  if (hasInvalid) {
+    window.alert('Donanım tipi ve miktar alanları zorunludur. Lütfen eksik bilgileri tamamlayın.');
+    return;
+  }
+
+  const submissionDate = new Date().toLocaleDateString('tr-TR');
+  const generatedIfs = trimmedIfs || generateIfsNo();
+
+  activeItems.forEach((item) => {
+    const { route, label } = resolveTargetLink(item.hardwareType);
+    const newRequest: RequestRecord = {
+      id: `RQ-${Math.floor(Math.random() * 9000 + 1000)}`,
+      ifsNo: generatedIfs,
+      status: 'open',
+      hardwareType: item.hardwareType,
+      brand: item.brand || 'Belirtilmedi',
+      model: item.model || 'Belirtilmedi',
+      quantity: item.quantity || '1 Adet',
+      date: submissionDate,
+      note: item.note || 'Yeni talep kaydı oluşturuldu.',
+      targetRoute: route,
+      targetLabel: label
+    };
+
+    requests.value.unshift(newRequest);
+  });
+
+  selectedStatus.value = 'open';
+  closeRequestForm();
+};
+
+const cancelRequest = (request: RequestRecord) => {
+  const reason = window.prompt('İptal sebebini giriniz', request.cancellationReason ?? '');
+
+  if (reason === null) {
+    return;
+  }
+
+  const trimmedReason = reason.trim();
+  const index = requests.value.findIndex((item) => item.id === request.id);
+
+  if (index === -1) {
+    return;
+  }
+
+  const previousRecord = requests.value[index];
+  const updatedRecord: RequestRecord = {
+    ...previousRecord,
+    status: 'cancelled',
+    date: new Date().toLocaleDateString('tr-TR'),
+    cancellationReason: trimmedReason || undefined,
+    note: trimmedReason
+      ? `${previousRecord.note.replace(/\s*\/\s*İptal sebebi:.*/, '')} / İptal sebebi: ${trimmedReason}`
+      : `${previousRecord.note.replace(/\s*\/\s*İptal sebebi:.*/, '')} / İptal sebebi belirtilmedi.`
+  };
+
+  requests.value.splice(index, 1, updatedRecord);
+  selectedStatus.value = 'cancelled';
+};
 </script>
 
-<style scoped src="@/styles/workspace.css"></style>
+<style scoped>
+.request-page {
+  display: grid;
+  gap: 2rem;
+  color: #0f172a;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2.4rem 2.8rem;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 32px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.08);
+}
+
+.header-copy {
+  display: grid;
+  gap: 0.85rem;
+  max-width: 560px;
+}
+
+.page-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: 2.15rem;
+}
+
+.header-copy p {
+  margin: 0;
+  color: #475569;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(148, 163, 184, 0.16);
+  color: #0f172a;
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.icon-button:hover {
+  background: rgba(148, 163, 184, 0.28);
+}
+
+.ghost-button,
+.primary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 14px;
+  padding: 0.75rem 1.6rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ghost-button {
+  background: rgba(248, 250, 252, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: #1f2937;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.ghost-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.1);
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #f8fafc;
+  box-shadow: 0 20px 34px rgba(37, 99, 235, 0.28);
+}
+
+.primary-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 40px rgba(37, 99, 235, 0.32);
+}
+
+.table-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 32px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 26px 50px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 1.75rem;
+  padding: 2rem 2.4rem 2.4rem;
+}
+
+.table-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.status-tabs {
+  display: inline-flex;
+  background: rgba(248, 250, 252, 0.85);
+  padding: 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  width: fit-content;
+}
+
+.tab-button {
+  position: relative;
+  border: none;
+  background: transparent;
+  color: #1f2937;
+  font-weight: 600;
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tab-button.active {
+  background: #2563eb;
+  color: #f8fafc;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.35);
+}
+
+.tab-button:not(.active):hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.tab-count {
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.tab-copy {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.tab-copy h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.tab-copy p {
+  margin: 0;
+  color: #475569;
+  max-width: 540px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.table-wrapper {
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(248, 250, 252, 0.7);
+  overflow: hidden;
+}
+
+.request-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.request-table thead {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(14, 116, 144, 0.12));
+}
+
+.request-table th {
+  text-align: left;
+  padding: 1rem 1.3rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #1f2937;
+}
+
+.request-table td {
+  padding: 1.1rem 1.3rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  color: #0f172a;
+  vertical-align: top;
+}
+
+.request-table tbody tr:first-of-type td {
+  border-top: none;
+}
+
+.table-actions {
+  text-align: right;
+}
+
+.action-group {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.action-button.stock {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.15);
+}
+
+.action-button.stock:hover {
+  background: #2563eb;
+  color: #f8fafc;
+}
+
+.action-button.cancel {
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+  box-shadow: 0 12px 24px rgba(220, 38, 38, 0.15);
+}
+
+.action-button.cancel:hover {
+  background: #dc2626;
+  color: #fef2f2;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.48);
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 2.5rem);
+  z-index: 40;
+}
+
+.modal-dialog {
+  width: min(880px, 100%);
+  background: #ffffff;
+  border-radius: 28px;
+  box-shadow: 0 40px 120px rgba(15, 23, 42, 0.22);
+  display: flex;
+  flex-direction: column;
+  max-height: min(90vh, 780px);
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 2rem 2.5rem 1.5rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.24);
+}
+
+.modal-title-group {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.modal-title-group h2 {
+  margin: 0;
+  font-size: 1.65rem;
+}
+
+.modal-title-group p {
+  margin: 0;
+  color: #64748b;
+  max-width: 480px;
+}
+
+.modal-body {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.75rem 2.5rem 2rem;
+  overflow-y: auto;
+}
+
+.field-label {
+  font-weight: 600;
+  color: #1e293b;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.optional {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+.text-input,
+.select-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.36);
+  font-size: 0.95rem;
+  background: #f8fafc;
+  color: #0f172a;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.text-input:focus,
+.select-input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
+  background: #ffffff;
+}
+
+.line-items-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.line-items-toolbar h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: #2563eb;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 12px;
+  transition: background 0.2s ease;
+}
+
+.link-button:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.line-items-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.line-items-head,
+.line-items-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.line-items-head {
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #94a3b8;
+  padding: 0 0.25rem;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1.5rem 2.5rem 2rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.24);
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.6) 0%, rgba(241, 245, 249, 0.9) 100%);
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 960px) {
+  .modal-dialog {
+    border-radius: 20px;
+  }
+
+  .line-items-head,
+  .line-items-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .line-items-head {
+    display: none;
+  }
+
+  .line-items-row {
+    gap: 0.5rem;
+  }
+}
+
+@media (max-width: 1024px) {
+  .page-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .header-actions {
+    justify-content: flex-start;
+  }
+
+  .table-card {
+    padding: 1.75rem;
+  }
+}
+
+@media (max-width: 840px) {
+  .status-tabs {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .tab-button {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+
+  .request-table thead {
+    display: none;
+  }
+
+  .request-table tr {
+    display: grid;
+    gap: 0.6rem;
+    padding: 1.1rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  }
+
+  .request-table tbody tr:last-of-type {
+    border-bottom: none;
+  }
+
+  .request-table td {
+    padding: 0;
+    border: none;
+  }
+
+  .request-table td::before {
+    content: attr(data-title);
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #64748b;
+    margin-bottom: 0.25rem;
+  }
+
+  .table-wrapper {
+    background: rgba(255, 255, 255, 0.92);
+  }
+
+  .table-actions {
+    text-align: left;
+  }
+
+  .action-group {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .action-button {
+    flex: 1 1 140px;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- introduce a Talep Aç modal with optional IFS input and dynamic line item grid on the request tracking view
- add reactive form state that validates entries and routes new requests to the appropriate module
- style the modal with responsive layout, focus treatments, and toolbar interactions to match the provided design

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68f23ab7520c832ba856d28685729b82